### PR TITLE
Refactor JSONWriter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fact-tools</artifactId>
 	<name>fact-tools</name>
 
-	<version>0.11.0</version>
+	<version>0.12.0</version>
 
 	<url>http://sfb876.de/fact-tools/</url>
 

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -144,12 +144,13 @@ public class JSONWriter implements StatefulProcessor {
         bw = new BufferedWriter(new FileWriter(new File(url.getFile()), append));
 
         GsonBuilder gsonBuilder  = new GsonBuilder().serializeSpecialFloatingPointValues();
+        gsonBuilder.enableComplexMapKeySerialization();
+
         if (doubleSignDigits != null) {
             DoubleAdapter doubleAdapter = new DoubleAdapter();
             doubleAdapter.setSignDigits(doubleSignDigits);
             gsonBuilder.registerTypeAdapter(double.class, doubleAdapter)
-                    .registerTypeAdapter(Double.class, doubleAdapter)
-                    .enableComplexMapKeySerialization();
+                    .registerTypeAdapter(Double.class, doubleAdapter);
         }
 
         if (pixelSetsAsInt){

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -22,25 +22,52 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.net.URL;
-import java.util.Arrays;
+
 
 /**
- * Writes a file containing a hopefully valid JSON String on each line.
- * Heres a simple Pyhton script to read it:
-
- import json
-
- def main():
-    with open('test.json', 'r') as file:
-        for line in file:
-            event = json.loads(line)
-            print(event['NROI'])
-
- if __name__ == "__main__":
-    main()
+ * Writes a keys from the data item to .json files.
+ * The format will be:
+ * <code>
+ *   [
+ *     {"key1": value, ...},
+ *     ...,
+ *     {"key1": value, ...}
+ *   ]
+ * <code/>
  *
+ * keys is evaluated using the stream.Keys class, so wild cards
+ * <code>*<code/>, <code>?<code/> and negations with <code>!</code> are possible:
  *
- * Keep in mind that some events might have keys missing.
+ * <code>
+ *     <fact.io.JSONWrite keys="*Pointing,!AzPointing" url="file:test.json" />
+ * </code>
+ * Will write all keys ending with `Pointing` to the json file but not AzPointing.
+ *
+ * The writer also supports the .jsonl format.
+ * http://jsonlines.org/
+ * To use the .jsonl format provide the key jsonl="true" in the xml.
+ *
+ * In this case the format will be:
+ * <code>
+ *     {"key1": value, ...}
+ *     ...
+ *     {"key1": value, ...}
+ * </code>
+ * To be able to store special float values we use the extension of the json standard
+ * found in most implementations. E. g. Google's gson, most JavaScript parsers and python's json module.
+ * So we use Infinity, -Infinity and NaN.
+ * python's pandas das not support this format directly, so use json to load the data and then create the DataFrame:
+ * <code>
+ *     import json
+ *     import pandas as pd
+ *     with open('test.json', 'r') as f:
+ *         data = json.load(f)
+ *     df = pd.DataFrame(data)
+ * </code>
+ *
+ * The following keys are added by default to the output:
+ * EventNum, TriggerType, NROI, NPIX
+ *
  * Created by bruegge on 7/30/14.
  */
 public class JSONWriter implements StatefulProcessor {

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -65,6 +65,11 @@ import java.net.URL;
  *     df = pd.DataFrame(data)
  * </code>
  *
+ *
+ * fact.container.PixelSet is converted to an array of chids by default,
+ * if you want to have the full output of this container, set
+ * <code>pixelSetsAsInt="false"</code>
+ *
  * The following keys are added by default to the output:
  * EventNum, TriggerType, NROI, NPIX
  *

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -55,7 +55,7 @@ import java.net.URL;
  * </code>
  * To be able to store special float values we use the extension of the json standard
  * found in most implementations. E. g. Google's gson, most JavaScript parsers and python's json module.
- * So we use Infinity, -Infinity and NaN.
+ * So we are using Infinity, -Infinity and NaN by default.
  * python's pandas das not support this format directly, so use json to load the data and then create the DataFrame:
  * <code>
  *     import json
@@ -170,8 +170,8 @@ public class JSONWriter implements StatefulProcessor {
     @Override
     public void finish() throws Exception {
         try {
-
             if(bw != null) {
+                bw.newLine();
                 if (!jsonl)
                 {
                     bw.write("]");

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -80,10 +80,9 @@ public class JSONWriter implements StatefulProcessor {
 
     @Parameter(required = true)
     private Keys keys = new Keys("");
-    @Parameter(required = false, description = "Defines how many significant digit are used for double values", defaultValue="null")
+    @Parameter(required = false, description = "Defines how many significant digits are used for double values", defaultValue="null")
     private Integer doubleSignDigits = null;
-    @Parameter(required = false, description = "If true a list of data items is written (and therefore the output file is a valid"
-    		+ "json object", defaultValue = "false")
+    @Parameter(required = false, description = "If true, use jsonl format instead of json format", defaultValue = "false")
     private boolean jsonl = false;
 
     @Parameter(required = false, description = "If true, PixelSets are written out as int arrays of chids", defaultValue = "true")

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -9,6 +9,7 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import fact.container.PixelSet;
 import stream.Data;
+import stream.Keys;
 import stream.ProcessContext;
 import stream.StatefulProcessor;
 import stream.annotations.Parameter;
@@ -46,7 +47,7 @@ public class JSONWriter implements StatefulProcessor {
 
 
     @Parameter(required = true)
-    private String[] keys;
+    private Keys keys = new Keys("");
     @Parameter(required = false, description = "Defines how many significant digit are used for double values", defaultValue="null")
     private Integer doubleSignDigits = null;
     @Parameter(required = false, description = "If true a list of data items is written (and therefore the output file is a valid"
@@ -62,6 +63,7 @@ public class JSONWriter implements StatefulProcessor {
     private Gson gson;
     private StringBuffer b = new StringBuffer();
     private BufferedWriter bw;
+    private String[] defaultKeys = {"EventNum", "TriggerType", "NROI", "NPIX"};
     
     boolean isFirstLine = true;
 
@@ -69,15 +71,14 @@ public class JSONWriter implements StatefulProcessor {
     public Data process(Data data) {
         Data item = DataFactory.create();
 
-        String[] evKeys = {"EventNum", "TriggerType", "NROI", "NPIX"};
-        for(String key : evKeys) {
-            if (data.containsKey(key)) {
-                item.put(key, data.get(key));
-            }
-        }
-        for (String key: keys){
+        for (String key: defaultKeys ){
             item.put(key, data.get(key));
         }
+
+        for (String key: keys.select(data) ){
+            item.put(key, data.get(key));
+        }
+
         try {
         	if (isFirstLine)
         	{
@@ -149,16 +150,9 @@ public class JSONWriter implements StatefulProcessor {
     }
 
 
-    public String[] getKeys() {
-        return keys;
-    }
-    public void setKeys(String[] keys) {
+
+    public void setKeys(Keys keys) {
         this.keys = keys;
-    }
-
-
-    public URL getUrl() {
-        return url;
     }
 
     public void setUrl(URL url) {

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -73,6 +73,11 @@ import java.net.URL;
  * The following keys are added by default to the output:
  * EventNum, TriggerType, NROI, NPIX
  *
+ * By default, the JSONWriter overwrites an existing file, if you want to append
+ * (which actually only makes sense if <code>jsonl="true</code>,
+ * you can use:
+ * <code>append="true"</code>
+ *
  * Created by bruegge on 7/30/14.
  */
 public class JSONWriter implements StatefulProcessor {
@@ -84,7 +89,8 @@ public class JSONWriter implements StatefulProcessor {
     private Integer doubleSignDigits = null;
     @Parameter(required = false, description = "If true, use jsonl format instead of json format", defaultValue = "false")
     private boolean jsonl = false;
-
+    @Parameter(required = false, description = "If true, append to existing file else overwrite", defaultValue = "false")
+    private  boolean append = false;
     @Parameter(required = false, description = "If true, PixelSets are written out as int arrays of chids", defaultValue = "true")
     private boolean pixelSetsAsInt = true;
 
@@ -135,7 +141,7 @@ public class JSONWriter implements StatefulProcessor {
 
     @Override
     public void init(ProcessContext processContext) throws Exception {
-        bw = new BufferedWriter(new FileWriter(new File(url.getFile())));
+        bw = new BufferedWriter(new FileWriter(new File(url.getFile()), append));
 
         GsonBuilder gsonBuilder  = new GsonBuilder().serializeSpecialFloatingPointValues();
         if (doubleSignDigits != null) {
@@ -180,7 +186,9 @@ public class JSONWriter implements StatefulProcessor {
         }
     }
 
-
+    public void setAppend(boolean append) {
+        this.append = append;
+    }
 
     public void setKeys(Keys keys) {
         this.keys = keys;

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -52,7 +52,7 @@ public class JSONWriter implements StatefulProcessor {
     private Integer doubleSignDigits = null;
     @Parameter(required = false, description = "If true a list of data items is written (and therefore the output file is a valid"
     		+ "json object", defaultValue = "false")
-    private boolean writeListOfItems = false;
+    private boolean jsonl = false;
 
     @Parameter(required = false, description = "If true, PixelSets are written out as int arrays of chids", defaultValue = "true")
     private boolean pixelSetsAsInt = true;
@@ -86,7 +86,7 @@ public class JSONWriter implements StatefulProcessor {
         	}
         	else
         	{
-        		if (writeListOfItems)
+        		if (!jsonl)
         		{
         			bw.write(",");
         		}
@@ -121,7 +121,7 @@ public class JSONWriter implements StatefulProcessor {
 
         gson = gsonBuilder.create();
 
-        if (writeListOfItems)
+        if (!jsonl)
         {
         	bw.write("[");
         }
@@ -135,13 +135,13 @@ public class JSONWriter implements StatefulProcessor {
         try {
 
             if(bw != null) {
-                if (writeListOfItems)
+                if (!jsonl)
                 {
                     bw.write("]");
                 }
             }
         } catch (IOException e){
-            //ignore stream was bw was cloes apparently
+            // ignore stream bw was closed apparently
         } finally {
             if (bw != null){
                 bw.close();
@@ -159,16 +159,15 @@ public class JSONWriter implements StatefulProcessor {
         this.url = url;
     }
 
+    public void setJsonl(boolean jsonl) {
+        this.jsonl = jsonl;
+    }
 
-	public void setDoubleSignDigits(int doubleSignDigits) {
+    public void setDoubleSignDigits(int doubleSignDigits) {
 		this.doubleSignDigits = doubleSignDigits;
 	}
 
-	public void setWriteListOfItems(boolean writeListOfItems) {
-		this.writeListOfItems = writeListOfItems;
-	}
-
-    public void setPixelSetsAsInt(boolean pixelSetsAsInt) {
+	public void setPixelSetsAsInt(boolean pixelSetsAsInt) {
         this.pixelSetsAsInt = pixelSetsAsInt;
     }
 


### PR DESCRIPTION
This includes the following changes:

* `json` format by default, optional `jsonl` format by using `jsonl="true"` in the `xml`
* New `append` option, default is false, so existing files are overwritten.
* The `keys` key is now evaluated using the `stream.Keys` class, so glob patterns now work.
* Increase version number to 0.12 because these changes break xmls.

No xmls in the example folder needed to be changed, although they are no behaving differently (output is `json`, not `jsonl` now).


One might want to add an Option to convert `Infinity`, `-Infinity` and `NaN` to something strictly `json` compatible.

What would you like? `null`? Or strings like `"nan", "inf", "-inf"`
