### PR TITLE
Ignore borked ceres files. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>0.16.0</version>
+  <version>0.16.1</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>
@@ -18,7 +18,7 @@
     <streams.version>0.9.23</streams.version>
     <binary.name>fact-tools-${project.version}</binary.name>
     <skipTests>false</skipTests>
-    <finalName>fact-tools-${project.version}</finalName>
+    <finalName>fact-tools-v${project.version}</finalName>
   </properties>
 
   <licenses>

--- a/src/main/java/fact/io/FactFileListMultiStream.java
+++ b/src/main/java/fact/io/FactFileListMultiStream.java
@@ -143,6 +143,9 @@ public class FactFileListMultiStream extends AbstractMultiStream {
                 stream.init();
 
                 data = stream.readNext();
+                if(data == null){
+                    throw new IOException("New file did not return data. Possibly empty file");
+                }
                 data.put("@drsFile", dataDrsPair.drsFile);
                 filesCounter++;
             }

--- a/src/main/java/fact/io/zfits/ZFitsStream.java
+++ b/src/main/java/fact/io/zfits/ZFitsStream.java
@@ -81,6 +81,12 @@ public class ZFitsStream extends AbstractStream{
             throw new FileNotFoundException("Cannot read file");
         }
 
+        //check file size. if its below 5k we simply return
+        if (f.length() < 5000){
+            log.warn("File is small (below 5KB) and probably empty. File size in bytes: " + f.length());
+            return;
+        }
+
         DataInputStream dataStream = new DataInputStream(new BufferedInputStream(url.openStream(), bufferSize));
         dataStream.mark(3000000);
         //read the header and output some information
@@ -186,9 +192,11 @@ public class ZFitsStream extends AbstractStream{
     @Override
     public Data readNext() throws Exception {
 
+        //no data in header. no initialization took place.
         if (this.tableReader == null) {
-            throw new NullPointerException("Didn't initialize the reader, should never happen.");
+            return null;
         }
+
         //get the next row of data. When its null the file has ended
         byte[][] dataRow = this.tableReader.readNextRow();
         if (dataRow == null) {


### PR DESCRIPTION
This is a suggestion (you might call it a dirty hack) to deal with 'empty' ceres files. 
Sometimes ceres writes fits.gz files with a file size of < 5KB.  These contain part of a .fits header. However the `END` keyword is missing. thus they are not valid fits files imho. Trying to parse these files with the zfits reader fails. This pull request just checks the file size. If its less than 5 KB it will not try to parse it.   

Maybe we should not merge this but fix ceres instead...