### PR TITLE
Add some numpy to xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 #Changelog for the fact-tools
 
+# Version 0.17.3 -- 17.01.2017
+
+* add fact.utils.CastDoubleArrayToIntArray
+* add fact.utils.ElementwiseMultiplyDoubleArray
+
+
 # Version 0.17.2 -- 05.12.2016
 
 * Reduced noise in `WaveformFluctuations`
-* added pedestal parameters to stdAnalysis 
-* added WaveformFluctuations on shower pixel to the ouput of the standard analysis 
+* added pedestal parameters to stdAnalysis
+* added WaveformFluctuations on shower pixel to the ouput of the standard analysis
 
 ## Version 0.17.1 -- 29.11.2016
 
@@ -109,11 +115,11 @@ data item was ever written
 ## Version 0.13.2 -- 06.04.2016
 
 * new Processor: `fact.extraction.TimeOverThresholdTL` allows to calculate the time over Threshold for a given window on the Timeline
-* `fact.features.singlePulse.FWHMPulses` now uses Doubles instead of Ints and throws NaNs in case of out-of-boundary issues 
+* `fact.features.singlePulse.FWHMPulses` now uses Doubles instead of Ints and throws NaNs in case of out-of-boundary issues
 
 ## Version 0.13.1 -- 06.04.2016
 
-* new Processor `fact.extraction.MeanCorrelation` to calculate the average covariance and correlation of the time series of neighboring pixels 
+* new Processor `fact.extraction.MeanCorrelation` to calculate the average covariance and correlation of the time series of neighboring pixels
 
 
 ## Version 0.13.0 -- 16.02.2016
@@ -121,10 +127,10 @@ data item was ever written
 * new package `fact.features.muon`
   * move `fact.features.MuonHoughTransform` to `fact.features.muon.HoughTransform`
   * new Processor `fact.features.muon.CircularFit` to fit a circle to the light distribution
-  * new Processor `fact.feautures.muon.GaussianFit` to fit a gaussian to the radial light 
+  * new Processor `fact.feautures.muon.GaussianFit` to fit a gaussian to the radial light
   distribution
   * example xml to show how these work: examples/studies/muon_fitting.xml
-* exceptions occuring in the functional tests are now logged 
+* exceptions occuring in the functional tests are now logged
 * new Processor `UnixTimeUTC2DateTime` to convert from a tuple of (seconds, microsends)
 to a DateTime object
 * new TypeAdapter in `JSONWriter` to write out `DateTime` objects as ISO string
@@ -132,7 +138,7 @@ to a DateTime object
 
 ## Version 0.12.3
 
-* `JSONWriter` now supports directly writing gzipped files with the 
+* `JSONWriter` now supports directly writing gzipped files with the
 option `gzip="true"`
 
 ## Version 0.12.2
@@ -147,16 +153,16 @@ Changes:
 ## Version 0.12.1
 Other changes:
 
-* Deleted unused xml files in project root. 
+* Deleted unused xml files in project root.
 * Fixed a bug in the SQLiteService which only allowed for data taken in January.
 * Replaced empty test sqlite file with real one.
 
-Changes in `fact.io.JSONWriter` 
+Changes in `fact.io.JSONWriter`
 
 * `json` format by default, optional `jsonl` format by using `jsonl="true"` in the `xml`
 * New `append` option, default is false, so existing files are overwritten.
 * The `keys` key is now evaluated using the `stream.Keys` class, so glob patterns now work.
-* Add flag `specialDoubleValuesAsString` to write special Double as strings for strict json compatability. See Issue #92 for more details. Via default special values are converted to `Infinity`, `-Infinity` and `NaN`. 
+* Add flag `specialDoubleValuesAsString` to write special Double as strings for strict json compatability. See Issue #92 for more details. Via default special values are converted to `Infinity`, `-Infinity` and `NaN`.
 
 
 No xmls in the example folder needed to be changed, although they are no behaving differently (output is `json`, not `jsonl` now).
@@ -227,7 +233,7 @@ How to adapt the xml files:
 The new pixel set package allows to perform set operations (union, intersection, difference,...) on sets of pixels. These processors allow to take the set of pixels after cleaning and e.g. calculate the set of non shower pixel without broken pixels.
 There is now also a pixelsets.Length processor, calculating the length of a pixelsets and replacing the NumberOfPixelInShower processor
 
-### PixelSetOverlay instead of int array 
+### PixelSetOverlay instead of int array
 All processors that work on a set of pixels or have a pixel set as result where changed such that:
 - Instead of an int array a PixelSetOverlay is stored in the data item
 - The so far used int array with cleaned pixels was removed.
@@ -239,7 +245,7 @@ The WaveformFluctuationsPixelSample processor is changed that way that it is pos
 
 ### Miscellaneous changes:
 
-- The impact parameter is now added to the outputfile in the standard mc analysis    
+- The impact parameter is now added to the outputfile in the standard mc analysis
 
 
 ## Version 0.9.7
@@ -283,7 +289,7 @@ Therefore a few changes were made in comparison to the previous version:
 SourcePosition operator:
 - The operator now uses the whole timestamp not only the seconds of the event time for calculating
  the source position and the correct tracking report
-- The operator uses the earlier strategy to find the tracking report from the aux file. (This is for reproducibility, 
+- The operator uses the earlier strategy to find the tracking report from the aux file. (This is for reproducibility,
  it will be changed in version 0.9.0 to the closest strategy)
 
 cleaning.xml in the classpath:
@@ -298,16 +304,16 @@ stdAnalysis:
 - The old delay file is used (This is for reproducibility, it will be changed in version 0.9.0)
 
 ## Version 0.8.8
-Added a replacement process to measure the performance of individual Processors. 
+Added a replacement process to measure the performance of individual Processors.
 You can use it like this:
-        
+
         <process class="fact.PerformanceMeasuringProcess" url="file:./measured_runtime.json" id="1" input="fact"
                 warmupIterations="33">
 
 ## Version 0.8.6
 
 A new tutorial package has been added. It contains some simple processors that hopefully help to understand the basic concepts
-of the analysis. 
+of the analysis.
 
 
 ## Version 0.8.0
@@ -315,7 +321,7 @@ of the analysis.
 
 The `ZFitsCalibration` processor does no longer exist. Its being handled by the `ZfitsStream` itsself.
 For reading good old .fits files (or ceres output) you still need the `fact.io.FitsStream`.
- 
+
 To use any kind of data from an AuxFile you should now use the `AuxFileService` Service. (See the website for more details)
 
 The DrsCalibration processor now resides in the `fact.datacorrection` package along with such processors as
@@ -326,7 +332,7 @@ auxiliary files through the new AuxService. This fixes some bugs which would occ
 
 The SourcePosition operator now supports wobbled MonteCarlos (Ceres revision > 18159) and the output has been cleaned up.
 
-The major steps of the standard analysis have been grouped into .xml files which reside in classpath of the project. 
+The major steps of the standard analysis have been grouped into .xml files which reside in classpath of the project.
 (you can find them under ./src/main/resources/default/...)
 
 Cleaned up all the .xmls from the examples folder. All are checked by tests except for the GUI
@@ -359,10 +365,10 @@ Removed dependencies to old streams versions by removing all code depending on t
  `fact-tools/src/main/resources/long_term_constants_median.time.drs.fits`
 
 ## Version 0.7.5
- 
+
  The Camera and Plotting Windows in the viewer can now also show Arrays of types other than double.
  We also implemented a new DrsTimeCalibration which you call as follows:
- 
+
            <fact.datacorrection.DrsTimeCalibration
                    dataKey="DataCalibrated"
                    outputKey="DataCalibrationNeu"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>0.17.2</version>
+  <version>0.17.3</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/src/main/java/fact/utils/CastDoubleArrayToIntArray.java
+++ b/src/main/java/fact/utils/CastDoubleArrayToIntArray.java
@@ -23,8 +23,9 @@ public class CastDoubleArrayToIntArray implements Processor {
         double[] doubleArray = (double[]) input.get(inputKey);
         int[] intArray = new int[doubleArray.length];
 
-        for (int i=0; i<intArray.length; ++i)
+        for (int i=0; i<intArray.length; ++i){
             intArray[i] = (int) Math.round(doubleArray[i]);
+        }
 
         input.put(outputKey, intArray);
         return input;

--- a/src/main/java/fact/utils/CastDoubleArrayToIntArray.java
+++ b/src/main/java/fact/utils/CastDoubleArrayToIntArray.java
@@ -1,0 +1,40 @@
+package fact.utils;
+
+import stream.Data;
+import stream.Processor;
+import stream.annotations.Parameter;
+
+public class CastDoubleArrayToIntArray implements Processor {
+
+    @Parameter(
+        required = true,
+        description = "Key to your double array."
+    )
+    private String inputKey;
+
+    @Parameter(
+        required = true,
+        description = "Key to the output integer array."
+    )
+    protected String outputKey;
+
+    @Override
+    public Data process(Data input) {
+        double[] doubleArray = (double[]) input.get(inputKey);
+        int[] intArray = new int[doubleArray.length];
+
+        for (int i=0; i<intArray.length; ++i)
+            intArray[i] = (int) Math.round(doubleArray[i]);
+
+        input.put(outputKey, intArray);
+        return input;
+    }
+
+    public void setInputKey(String inputKey) {
+        this.inputKey = inputKey;
+    }
+    public void setOutputKey(String outputKey) {
+        this.outputKey = outputKey;
+    }
+
+}

--- a/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
+++ b/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
@@ -15,7 +15,7 @@ public class ElementwiseMultiplyDoubleArray implements Processor {
 
     @Parameter(
         required = true,
-        description = "Key to the output integer array."
+        description = "Key to the output double array."
     )
     protected String outputKey;
 

--- a/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
+++ b/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
@@ -1,0 +1,46 @@
+package fact.utils;
+
+import stream.Data;
+import stream.Processor;
+import stream.annotations.Parameter;
+import fact.features.singlePulse.timeSeriesExtraction.ElementWise;
+
+public class ElementwiseMultiplyDoubleArray implements Processor {
+
+    @Parameter(
+        required = true,
+        description = "Key to your double array."
+    )
+    private String inputKey;
+
+    @Parameter(
+        required = true,
+        description = "Key to the output integer array."
+    )
+    protected String outputKey;
+
+    @Parameter(
+        required = true,
+        description = "Factor to multiply with."
+    )
+    protected double factor;
+
+
+    @Override
+    public Data process(Data input) {
+        double[] doubleArray = (double[]) input.get(inputKey);
+        input.put(outputKey, ElementWise.multiply(doubleArray, factor));
+        return input;
+    }
+
+    public void setInputKey(String inputKey) {
+        this.inputKey = inputKey;
+    }
+    public void setOutputKey(String outputKey) {
+        this.outputKey = outputKey;
+    }
+    public void setFactor(double factor) {
+        this.factor = factor;
+    }
+
+}


### PR DESCRIPTION
Add two more processors which make the fact-tools XML feel a bit  more like numpy.

Now one can multiply a vector with a scalar (only if the vector is in fact a `double[]`)
and one can cast that `double[]` to an `int[]`.

I agree, it's not much and one would get this for free in a different environment, but its a step.

This PR is in connection to #182, since these two processors allow us to reduce the precision of the Baseline so it does not hurt that much anymore to write this noise to disk.
