### PR TITLE
add two processors converting photon stream to arrival time and #photons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 #Changelog for the fact-tools
 
+# Version 0.17.4 -- 17.01.2017
+
+* add fact.utils.PhotonStream2ArrivalTime
+* add fact.utils.PhotonStream2NumberOfPhotons
+
 # Version 0.17.3 -- 17.01.2017
 
 * output window: Cut out artifacts of SinglePulseExtractor.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>0.17.3</version>
+  <version>0.17.4</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
+++ b/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
@@ -33,6 +33,9 @@ public class PhotonStream2ArrivalTime implements Processor {
         Arrays.sort(pulses);  // acts in place, but I guess this is no problem.
 
         int len = pulses.length;
+        if (len == 0){
+            return 0; // The plot does not like Double.NaN, so I use 0.
+        }
         if (len%2 == 1 ){
             median =  pulses[(len - 1) / 2];
         } else {

--- a/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
+++ b/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
@@ -23,11 +23,15 @@ public class PhotonStream2ArrivalTime implements Processor {
         double[] arrivalTimes = new double[singlePulses.length];
 
         for (int pix = 0; pix < singlePulses.length; pix++) {
-            DescriptiveStatistics stat = new DescriptiveStatistics();
-            for (int slice: singlePulses[pix]){
-                stat.addValue((double) slice);
+            if (singlePulses[pix].length == 0){
+                arrivalTimes[pix] = 0.; // use zero instead of NaN - plotter likes no NaN
+            } else {
+                DescriptiveStatistics stat = new DescriptiveStatistics();
+                for (int slice: singlePulses[pix]){
+                    stat.addValue((double) slice);
+                }
+                arrivalTimes[pix] = stat.getPercentile(50);
             }
-            arrivalTimes[pix] = stat.getPercentile(50);
         }
         input.put(arrivalTimeKey, arrivalTimes);
         return input;

--- a/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
+++ b/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
@@ -1,0 +1,52 @@
+package fact.utils;
+
+import java.util.Arrays;
+import stream.Data;
+import stream.Processor;
+import stream.annotations.Parameter;
+
+public class PhotonStream2ArrivalTime implements Processor {
+    @Parameter(
+        required = true,
+        description = "The arrival slices of the single pulses.")
+    private String singlePulsesKey = null;
+
+    @Parameter(
+        required = true,
+        description = "The reconstruted arrival time")
+    private String arrivalTimeKey = null;
+
+    @Override
+    public Data process(Data input) {
+        int[][] singlePulses = (int[][]) input.get(singlePulsesKey);
+        double[] arrivalTimes = new double[singlePulses.length];
+
+        for (int pix = 0; pix < singlePulses.length; pix++) {
+            arrivalTimes[pix] = this.getMedian(singlePulses[pix]);
+        }
+        input.put(arrivalTimeKey, arrivalTimes);
+        return input;
+    }
+
+    public double getMedian(int[] pulses){
+        double median;
+        Arrays.sort(pulses);  // acts in place, but I guess this is no problem.
+
+        int len = pulses.length;
+        if (len%2 == 1 ){
+            median =  pulses[(len - 1) / 2];
+        } else {
+            median =(pulses[len/2] + pulses[len/2 - 1]) / 2.;
+        }
+        return median;
+    }
+
+    public void setSinglePulsesKey(String singlePulsesKey) {
+        this.singlePulsesKey = singlePulsesKey;
+    }
+
+    public void setArrivalTimeKey(String arrivalTimeKey) {
+        this.arrivalTimeKey = arrivalTimeKey;
+    }
+
+}

--- a/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
+++ b/src/main/java/fact/utils/PhotonStream2ArrivalTime.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import stream.Data;
 import stream.Processor;
 import stream.annotations.Parameter;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
 public class PhotonStream2ArrivalTime implements Processor {
     @Parameter(
@@ -22,26 +23,14 @@ public class PhotonStream2ArrivalTime implements Processor {
         double[] arrivalTimes = new double[singlePulses.length];
 
         for (int pix = 0; pix < singlePulses.length; pix++) {
-            arrivalTimes[pix] = this.getMedian(singlePulses[pix]);
+            DescriptiveStatistics stat = new DescriptiveStatistics();
+            for (int slice: singlePulses[pix]){
+                stat.addValue((double) slice);
+            }
+            arrivalTimes[pix] = stat.getPercentile(50);
         }
         input.put(arrivalTimeKey, arrivalTimes);
         return input;
-    }
-
-    public double getMedian(int[] pulses){
-        double median;
-        Arrays.sort(pulses);  // acts in place, but I guess this is no problem.
-
-        int len = pulses.length;
-        if (len == 0){
-            return 0; // The plot does not like Double.NaN, so I use 0.
-        }
-        if (len%2 == 1 ){
-            median =  pulses[(len - 1) / 2];
-        } else {
-            median =(pulses[len/2] + pulses[len/2 - 1]) / 2.;
-        }
-        return median;
     }
 
     public void setSinglePulsesKey(String singlePulsesKey) {

--- a/src/main/java/fact/utils/PhotonStream2NumberOfPhotons.java
+++ b/src/main/java/fact/utils/PhotonStream2NumberOfPhotons.java
@@ -1,0 +1,54 @@
+package fact.utils;
+
+import stream.Data;
+import stream.Processor;
+import stream.annotations.Parameter;
+
+public class PhotonStream2NumberOfPhotons implements Processor {
+    @Parameter(
+        required = true,
+        description = "The arrival slices of the single pulses.")
+    private String singlePulsesKey = null;
+
+    @Parameter(
+        required = true,
+        description = "The reconstruted arrival time")
+    private String arrivalTimeKey = null;
+
+    @Parameter(
+        required = true,
+        description = "The reconstruted number of photons")
+    private String numberOfPhotonsKey = null;
+
+    @Override
+    public Data process(Data input) {
+        int[][] singlePulses = (int[][]) input.get(singlePulsesKey);
+        double[] arrivalTimes = (double[]) input.get(arrivalTimeKey);
+        int[] numberOfPhotons = new int[singlePulses.length];
+
+        for (int pix = 0; pix < singlePulses.length; pix++) {
+            int[] pulses = singlePulses[pix];
+            for (int time_of_pulse: pulses){
+                if ((time_of_pulse >= arrivalTimes[pix] - 5) &&
+                    (time_of_pulse < arrivalTimes[pix] + 25)){
+                    numberOfPhotons[pix] += 1;
+                }
+            }
+        }
+        input.put(numberOfPhotonsKey, numberOfPhotons);
+        return input;
+    }
+
+    public void setSinglePulsesKey(String singlePulsesKey) {
+        this.singlePulsesKey = singlePulsesKey;
+    }
+
+    public void setArrivalTimeKey(String arrivalTimeKey) {
+        this.arrivalTimeKey = arrivalTimeKey;
+    }
+
+    public void setNumberOfPhotonsKey(String numberOfPhotonsKey) {
+        this.numberOfPhotonsKey = numberOfPhotonsKey;
+    }
+
+}


### PR DESCRIPTION
We discussed yesterday, that the baseline might not be necessary at all, and we might be able to study this, if we converted the photon stream back to the two most basic observables:

 * arrival time per pixel and
 * number of photons per pixel

Here is a very basic proposal for those processors... I am currently looking into them ... i.e. trying them out in the viewer.

However ... early feedback is much appreciated.