### PR TITLE
Control the output keys of the JSONWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #Changelog for the fact-tools
 
+# Version 0.17.4 -- 18.01.2017
+
+* No more default keys for the output writers (FITS and JSON). The former default keys are now among others set in 'src/main/resources/default/settings.properties'. 
+
 # Version 0.17.3 -- 17.01.2017
 
 * output window: Cut out artifacts of SinglePulseExtractor.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>0.17.3</version>
+  <version>0.17.4</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -47,8 +47,6 @@ public class FITSWriter implements StatefulProcessor {
     @Parameter(defaultValue ="Events", description = "EXTNAME for the binary table extension")
     private String extname = "Events";
 
-    private String[] defaultKeys = {"EventNum", "TriggerType", "NROI", "NPIX"};
-
     private BufferedFile bf;
     private ByteBuffer buffer;
     private BinaryTableHDU bhdu;
@@ -64,9 +62,6 @@ public class FITSWriter implements StatefulProcessor {
     public Data process(Data item) {
         Data outputItem = DataFactory.create();
 
-        for (String key: defaultKeys ){
-            outputItem.put(key, item.get(key));
-        }
         for (String key: keys.select(item) ){
             outputItem.put(key, item.get(key));
         }

--- a/src/main/java/fact/io/JSONWriter.java
+++ b/src/main/java/fact/io/JSONWriter.java
@@ -119,17 +119,12 @@ public class JSONWriter implements StatefulProcessor {
     private Gson gson;
     private StringBuffer b = new StringBuffer();
     private BufferedWriter bw;
-    private String[] defaultKeys = {"EventNum", "TriggerType", "NROI", "NPIX"};
     
     boolean isFirstLine = true;
 
     @Override
     public Data process(Data data) {
         Data item = DataFactory.create();
-
-        for (String key: defaultKeys ){
-            item.put(key, data.get(key));
-        }
 
         for (String key: keys.select(data) ){
             item.put(key, data.get(key));

--- a/src/main/resources/default/settings.properties
+++ b/src/main/resources/default/settings.properties
@@ -29,7 +29,7 @@ sourcename=crab
 
 # Outputkey Settings
 
-event_param=NIGHT,RUNID,EventNum,UnixTimeUTC
+event_param=NIGHT,RUNID,EventNum,TriggerType,NROI,NPIX,UnixTimeUTC
 tracking_param=AzTracking,ZdTracking,AzPointing,ZdPointing,AzSourceCalc,ZdSourceCalc
 
 stat_allPix_param=photonchargeMean,arrivalTimeMean


### PR DESCRIPTION
solves issue #191 
Gives us full control of what goes into the JSON files
Moves the duty of taking default keys into account to src/main/resources/default/settings.properties where some other defaults are already defined.