### PR TITLE
Fix bad package lines and imports

### DIFF
--- a/examples/studies/closedShutterGainCalibration.xml
+++ b/examples/studies/closedShutterGainCalibration.xml
@@ -63,8 +63,8 @@
     <!--<fact.filter.MovingLinearFit key="DataShaped" slopeKey="slope14" interceptKey="intercept14" scale="10" width="14"/>-->
     <!--<fact.filter.MovingLinearFit key="DataShaped" slopeKey="slope20" interceptKey="intercept20" scale="10" width="20"/>-->
     <fact.statistics.Derivation key="DataSmoothed" outputKey="slopeKey" />
-    <fact.photonstream.singlePulse.ArrivalTimeFromSlope key="DataSmoothed" outputKey="ArrivalTimesSlope" derivationKey="slopeKey" visualizeKey="slopeArrivalTimes" baselineKey="baselines" skipFirstSlices="20" skipLastSlices="120" />
-    <fact.photonstream.singlePulse.OpenShutterPulseSize key="DataSmoothed" outputKey="OpenPulseSizesSlope" arrivalTimeKey="ArrivalTimesSlope" baselineKey="baselines" width="30" />
+    <fact.features.singlePulse.ArrivalTimeFromSlope key="DataSmoothed" outputKey="ArrivalTimesSlope" derivationKey="slopeKey" visualizeKey="slopeArrivalTimes" baselineKey="baselines" skipFirstSlices="20" skipLastSlices="120" />
+    <fact.features.singlePulse.OpenShutterPulseSize key="DataSmoothed" outputKey="OpenPulseSizesSlope" arrivalTimeKey="ArrivalTimesSlope" baselineKey="baselines" width="30" />
     <!--<fact.io.JSONWriter url="file:/net/home.e5.physik.tu-dortmund.de/vol/ph_e5v/e5b/homes/jbuss/test.json" keys="OpenPulseSizesSlope,ArrivalTimesSlope,baselines"/>-->
     <!--         <fact.io.CreateNestedListFile DataOutputKey="OpenPulseSizesSlope" urlString="file:///net/home.e5.physik.tu-dortmund.de/vol/ph_e5v/e5b/homes/kgray/data/test/file-slope-open-pulses.txt" /> -->
     <!--         <fact.io.CreateNestedListFile DataOutputKey="ArrivalTimesSlope" urlString="file:///net/home.e5.physik.tu-dortmund.de/vol/ph_e5v/e5b/homes/kgray/data/test/file-slope-arrivalTimes.txt" /> -->

--- a/src/main/java/fact/features/singlePulse/ArrivalTime.java
+++ b/src/main/java/fact/features/singlePulse/ArrivalTime.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Constants;
 import fact.Utils;

--- a/src/main/java/fact/features/singlePulse/ArrivalTimeFromSlope.java
+++ b/src/main/java/fact/features/singlePulse/ArrivalTimeFromSlope.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 
 import fact.Utils;

--- a/src/main/java/fact/features/singlePulse/FindThresholdCrossings.java
+++ b/src/main/java/fact/features/singlePulse/FindThresholdCrossings.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Constants;
 import fact.Utils;

--- a/src/main/java/fact/features/singlePulse/OpenShutterPulseSize.java
+++ b/src/main/java/fact/features/singlePulse/OpenShutterPulseSize.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Utils;
 import org.slf4j.Logger;

--- a/src/main/java/fact/features/singlePulse/PulseMaxAmplitude.java
+++ b/src/main/java/fact/features/singlePulse/PulseMaxAmplitude.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Constants;
 import fact.Utils;

--- a/src/main/java/fact/features/singlePulse/PulseSizeCalculator.java
+++ b/src/main/java/fact/features/singlePulse/PulseSizeCalculator.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Constants;
 import fact.Utils;

--- a/src/main/java/fact/features/singlePulse/TimeOverThresholdArray.java
+++ b/src/main/java/fact/features/singlePulse/TimeOverThresholdArray.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package fact.photonstream.singlePulse;
+package fact.features.singlePulse;
 
 import fact.Constants;
 import fact.Utils;

--- a/src/main/java/fact/photonstream/ConvertSinglePulses2Timeseries.java
+++ b/src/main/java/fact/photonstream/ConvertSinglePulses2Timeseries.java
@@ -1,9 +1,9 @@
 package fact.photonstream;
 
-import fact.photonstream.singlePulse.timeSeriesExtraction.AddFirstArrayToSecondArray;
-import fact.photonstream.singlePulse.timeSeriesExtraction.SinglePulseExtractor;
-import fact.photonstream.singlePulse.timeSeriesExtraction.TemplatePulse;
-import fact.photonstream.singlePulse.timeSeriesExtraction.ElementWise;
+import fact.photonstream.timeSeriesExtraction.AddFirstArrayToSecondArray;
+import fact.photonstream.timeSeriesExtraction.SinglePulseExtractor;
+import fact.photonstream.timeSeriesExtraction.TemplatePulse;
+import fact.photonstream.timeSeriesExtraction.ElementWise;
 import org.apache.commons.lang3.ArrayUtils;
 import stream.Data;
 import stream.Processor;

--- a/src/main/java/fact/photonstream/SinglePulseExtraction.java
+++ b/src/main/java/fact/photonstream/SinglePulseExtraction.java
@@ -6,8 +6,8 @@ import stream.Data;
 import stream.Processor;
 import stream.annotations.Parameter;
 import java.util.Arrays;
-import fact.photonstream.singlePulse.timeSeriesExtraction.SinglePulseExtractor;
-import fact.photonstream.singlePulse.timeSeriesExtraction.ElementWise;
+import fact.photonstream.timeSeriesExtraction.SinglePulseExtractor;
+import fact.photonstream.timeSeriesExtraction.ElementWise;
 
 /**
  * Extracts a list of arrival slice positions of photons for each pixel

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/AddFirstArrayToSecondArray.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/AddFirstArrayToSecondArray.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 /**
  * Utility class for adding elements of two arrays

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/ArgMax.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/ArgMax.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 /**
 * Finds the maximum on an array and stores its position (arg)

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/Convolve.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/Convolve.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 /**
  * Utility class containing a method for convolving two arrays.

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/ElementWise.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/ElementWise.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 /**
  * A collection of element-wise operations on double[] arrays with a scalar.

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/SinglePulseExtractor.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/SinglePulseExtractor.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 import fact.Utils;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;

--- a/src/main/java/fact/photonstream/timeSeriesExtraction/TemplatePulse.java
+++ b/src/main/java/fact/photonstream/timeSeriesExtraction/TemplatePulse.java
@@ -1,4 +1,4 @@
-package fact.photonstream.singlePulse.timeSeriesExtraction;
+package fact.photonstream.timeSeriesExtraction;
 
 /**
  * The pulse shape of FACTs SiPMs. This class contains a single function returning

--- a/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
+++ b/src/main/java/fact/utils/ElementwiseMultiplyDoubleArray.java
@@ -3,7 +3,7 @@ package fact.utils;
 import stream.Data;
 import stream.Processor;
 import stream.annotations.Parameter;
-import fact.photonstream.singlePulse.timeSeriesExtraction.ElementWise;
+import fact.photonstream.timeSeriesExtraction.ElementWise;
 
 public class ElementwiseMultiplyDoubleArray implements Processor {
 

--- a/src/test/java/fact/features/AddFirstArrayToSecondArrayTest.java
+++ b/src/test/java/fact/features/AddFirstArrayToSecondArrayTest.java
@@ -3,7 +3,7 @@ package fact.features;
 import fact.Utils;
 import junit.framework.Assert;
 import org.junit.Test;
-import fact.photonstream.singlePulse.timeSeriesExtraction.AddFirstArrayToSecondArray;
+import fact.photonstream.timeSeriesExtraction.AddFirstArrayToSecondArray;
 
 public class AddFirstArrayToSecondArrayTest {
 

--- a/src/test/java/fact/features/ArgMaxTest.java
+++ b/src/test/java/fact/features/ArgMaxTest.java
@@ -3,7 +3,7 @@ package fact.features;
 import fact.Utils;
 import junit.framework.Assert;
 import org.junit.Test;
-import fact.photonstream.singlePulse.timeSeriesExtraction.ArgMax;
+import fact.photonstream.timeSeriesExtraction.ArgMax;
 
 public class ArgMaxTest {
 

--- a/src/test/java/fact/features/ConvolveTest.java
+++ b/src/test/java/fact/features/ConvolveTest.java
@@ -3,7 +3,7 @@ package fact.features;
 import fact.Utils;
 import junit.framework.Assert;
 import org.junit.Test;
-import fact.photonstream.singlePulse.timeSeriesExtraction.Convolve;
+import fact.photonstream.timeSeriesExtraction.Convolve;
 
 public class ConvolveTest {
 

--- a/src/test/java/fact/features/ElementWiseTest.java
+++ b/src/test/java/fact/features/ElementWiseTest.java
@@ -3,7 +3,7 @@ package fact.features;
 import fact.Utils;
 import junit.framework.Assert;
 import org.junit.Test;
-import fact.photonstream.singlePulse.timeSeriesExtraction.ElementWise;
+import fact.photonstream.timeSeriesExtraction.ElementWise;
 
 public class ElementWiseTest {
 

--- a/src/test/java/fact/features/SinglePulseExtractorTest.java
+++ b/src/test/java/fact/features/SinglePulseExtractorTest.java
@@ -2,9 +2,9 @@ package fact.features;
 
 import junit.framework.Assert;
 import org.junit.Test;
-import fact.photonstream.singlePulse.timeSeriesExtraction.TemplatePulse;
-import fact.photonstream.singlePulse.timeSeriesExtraction.SinglePulseExtractor;
-import fact.photonstream.singlePulse.timeSeriesExtraction.AddFirstArrayToSecondArray;
+import fact.photonstream.timeSeriesExtraction.TemplatePulse;
+import fact.photonstream.timeSeriesExtraction.SinglePulseExtractor;
+import fact.photonstream.timeSeriesExtraction.AddFirstArrayToSecondArray;
 
 public class SinglePulseExtractorTest {
 


### PR DESCRIPTION
I created a mess by not using a fancy IDE with the package lines and import lines for the ```fact.photonstream``` and the  ```fact.features.singlePulse``` packages. Although it did not cause the tests to fail (WTF is going on with these package lines? They seem to be unneeded.), I want to make it better again.