### PR TITLE
Reimplement conc core

### DIFF
--- a/src/main/java/fact/Utils.java
+++ b/src/main/java/fact/Utils.java
@@ -349,22 +349,17 @@ public class Utils {
 	 * @param delta
 	 * @return an array having two elements {l, t}
 	 */
-	public static double[] transformToEllipseCoordinates(double x, double y,
-			double cogX, double cogY, double delta) {
+	public static double[] transformToEllipseCoordinates(double x, double y, double cogX, double cogY, double delta) {
 		double translatedX = x - cogX;
 		double translatedY = y - cogY;
 
-		double dist = Math.sqrt(translatedX * translatedX + translatedY
-				* translatedY);
+		double sinDelta = Math.sin(delta);
+		double cosDelta = Math.cos(delta);
 
-		double beta = Math.atan2(translatedY, translatedX);
-		double alpha = (beta - delta);
+		double l = cosDelta * translatedX + sinDelta * translatedY;
+		double t = -sinDelta * translatedX + cosDelta * translatedY;
 
-		double t = Math.sin(alpha) * dist;
-		double l = Math.cos(alpha) * dist;
-		double[] c = { l, t };
-
-		return c;
+		return new double[]{l, t};
 	}
 
     public static double calculateDistancePointToShowerAxis(double cogx, double cogy, double delta, double x, double y){

--- a/src/main/java/fact/features/ConcentrationCore.java
+++ b/src/main/java/fact/features/ConcentrationCore.java
@@ -54,27 +54,21 @@ public class ConcentrationCore implements Processor{
 
 
 		double photonsInEllipse = 0;
-
 		for(CameraPixel pix : showerPixelSet.set)
 		{
 			FactCameraPixel p = FactPixelMapping.getInstance().getPixelFromId(pix.id);
 			double px = p.getXPositionInMM();
 			double py = p.getYPositionInMM();
 
-			double dx = px - cogx;
-			double dy = py - cogy;
+			double[] ellipseCoords = Utils.transformToEllipseCoordinates(px, py, cogx, cogy, delta);
 
-			double pixelLong = Math.cos(delta) * dx - Math.sin(delta) * dy;
-			double pixelTrans = Math.sin(delta) * dx + Math.cos(delta) * dy;
-
-			double distance = Math.pow(pixelLong / length, 2.0) + Math.pow(pixelTrans / width, 2.0);
+			double distance = Math.pow(ellipseCoords[0] / length, 2.0) + Math.pow(ellipseCoords[1] / width, 2.0);
 
 			if (distance <= 1) {
 				photonsInEllipse += photonChargeArray[pix.id];
 			}
 		}
 		double concCore = photonsInEllipse / size;
-
 		input.put(outputKey, concCore);
 		return input;
 	}

--- a/src/main/java/fact/features/ConcentrationCore.java
+++ b/src/main/java/fact/features/ConcentrationCore.java
@@ -1,5 +1,6 @@
 package fact.features;
 
+import fact.Constants;
 import fact.Utils;
 import fact.container.PixelSet;
 import fact.hexmap.CameraPixel;
@@ -62,7 +63,11 @@ public class ConcentrationCore implements Processor{
 
 			double[] ellipseCoords = Utils.transformToEllipseCoordinates(px, py, cogx, cogy, delta);
 
-			double distance = Math.pow(ellipseCoords[0] / length, 2.0) + Math.pow(ellipseCoords[1] / width, 2.0);
+			// add a tolerance of 10% of the pixel size to not only get pixels with the center in the ellipse
+			double dl = Math.abs(ellipseCoords[0]) - 0.1 * Constants.PIXEL_SIZE;
+			double dt = Math.abs(ellipseCoords[1]) - 0.1 * Constants.PIXEL_SIZE;
+
+			double distance = Math.pow(dl / length, 2.0) + Math.pow(dt / width, 2.0);
 
 			if (distance <= 1) {
 				photonsInEllipse += photonChargeArray[pix.id];

--- a/src/main/java/fact/features/ConcentrationCore.java
+++ b/src/main/java/fact/features/ConcentrationCore.java
@@ -1,7 +1,5 @@
 package fact.features;
 
-
-import fact.Constants;
 import fact.Utils;
 import fact.container.PixelSet;
 import fact.hexmap.CameraPixel;
@@ -12,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import stream.Data;
 import stream.Processor;
 import stream.annotations.Parameter;
-import streams.tikz.Pixel;
 
 
 public class ConcentrationCore implements Processor{

--- a/src/main/java/fact/features/ConcentrationCore.java
+++ b/src/main/java/fact/features/ConcentrationCore.java
@@ -46,50 +46,43 @@ public class ConcentrationCore implements Processor{
 
 		Utils.mapContainsKeys( input, cogxKey, cogyKey, deltaKey, photonChargeKey, pixelSetKey, lengthKey, widthKey, sizeKey);
 
-		try{
-			Double cogx = (Double) input.get(cogxKey);
-			Double cogy = (Double) input.get(cogyKey);
-			Double delta = (Double) input.get(deltaKey);
-			double [] photonChargeArray = (double[]) input.get(photonChargeKey);
-			PixelSet showerPixelSet = (PixelSet) input.get(pixelSetKey);
-			Double length = (Double) input.get(lengthKey);
-			Double width = (Double) input.get(widthKey);
-			Double size = (Double) input.get(sizeKey);
+		Double cogx = (Double) input.get(cogxKey);
+		Double cogy = (Double) input.get(cogyKey);
+		Double delta = (Double) input.get(deltaKey);
+		double [] photonChargeArray = (double[]) input.get(photonChargeKey);
+		PixelSet showerPixelSet = (PixelSet) input.get(pixelSetKey);
+		Double length = (Double) input.get(lengthKey);
+		Double width = (Double) input.get(widthKey);
+		Double size = (Double) input.get(sizeKey);
 
 
-			double photonsInEllipse = 0;
+		double photonsInEllipse = 0;
 
-			PixelSet corePixels = new PixelSet();
-			for(CameraPixel pix : showerPixelSet.set)
-			{
-                FactCameraPixel p = FactPixelMapping.getInstance().getPixelFromId(pix.id);
-				double px = p.getXPositionInMM();
-				double py = p.getYPositionInMM();
+		PixelSet corePixels = new PixelSet();
+		for(CameraPixel pix : showerPixelSet.set)
+		{
+			FactCameraPixel p = FactPixelMapping.getInstance().getPixelFromId(pix.id);
+			double px = p.getXPositionInMM();
+			double py = p.getYPositionInMM();
 
-				double dx = px - cogx;
-				double dy = py - cogy;
+			double dx = px - cogx;
+			double dy = py - cogy;
 
-				double pixelLong = Math.cos(delta) * dx - Math.sin(delta) * dy;
-				double pixelTrans = Math.sin(delta) * dx + Math.cos(delta) * dy;
+			double pixelLong = Math.cos(delta) * dx - Math.sin(delta) * dy;
+			double pixelTrans = Math.sin(delta) * dx + Math.cos(delta) * dy;
 
-				double distance = Math.pow(pixelLong / length, 2.0) + Math.pow(pixelTrans / width, 2.0);
+			double distance = Math.pow(pixelLong / length, 2.0) + Math.pow(pixelTrans / width, 2.0);
 
-				if (distance <= 1) {
-					photonsInEllipse += photonChargeArray[pix.id];
-					corePixels.add(pix);
-				}
+			if (distance <= 1) {
+				photonsInEllipse += photonChargeArray[pix.id];
+				corePixels.add(pix);
 			}
-			double concCore = photonsInEllipse / size;
-
-			input.put(outputKey, concCore);
-			input.put("CorePixels", corePixels);
-			return input;
-
-		} catch (ClassCastException e){
-			log.error("Could not cast the values to the right types");
-			throw e;
 		}
+		double concCore = photonsInEllipse / size;
 
+		input.put(outputKey, concCore);
+		input.put("CorePixels", corePixels);
+		return input;
 	}
 
 	public String getOutputKey() {

--- a/src/main/java/fact/features/ConcentrationCore.java
+++ b/src/main/java/fact/features/ConcentrationCore.java
@@ -58,7 +58,6 @@ public class ConcentrationCore implements Processor{
 
 		double photonsInEllipse = 0;
 
-		PixelSet corePixels = new PixelSet();
 		for(CameraPixel pix : showerPixelSet.set)
 		{
 			FactCameraPixel p = FactPixelMapping.getInstance().getPixelFromId(pix.id);
@@ -75,84 +74,11 @@ public class ConcentrationCore implements Processor{
 
 			if (distance <= 1) {
 				photonsInEllipse += photonChargeArray[pix.id];
-				corePixels.add(pix);
 			}
 		}
 		double concCore = photonsInEllipse / size;
 
 		input.put(outputKey, concCore);
-		input.put("CorePixels", corePixels);
 		return input;
 	}
-
-	public String getOutputKey() {
-		return outputKey;
-	}
-
-	public void setOutputKey(String outputKey) {
-		this.outputKey = outputKey;
-	}
-
-	public String getCogxKey() {
-		return cogxKey;
-	}
-
-	public void setCogxKey(String cogxKey) {
-		this.cogxKey = cogxKey;
-	}
-
-	public String getCogyKey() {
-		return cogyKey;
-	}
-
-	public void setCogyKey(String cogyKey) {
-		this.cogyKey = cogyKey;
-	}
-
-	public String getDeltaKey() {
-		return deltaKey;
-	}
-
-	public void setDeltaKey(String deltaKey) {
-		this.deltaKey = deltaKey;
-	}
-
-	public String getSizeKey() {
-		return sizeKey;
-	}
-
-	public void setSizeKey(String sizeKey) {
-		this.sizeKey = sizeKey;
-	}
-
-	public String getPhotonChargeKey() {
-		return photonChargeKey;
-	}
-
-	public void setPhotonChargeKey(String photonChargeKey) {
-		this.photonChargeKey = photonChargeKey;
-	}
-
-	public void setPixelSetKey(String pixelSetKey) {
-		this.pixelSetKey = pixelSetKey;
-	}
-
-	public String getWidthKey() {
-		return widthKey;
-	}
-
-	public void setWidthKey(String widthKey) {
-		this.widthKey = widthKey;
-	}
-
-	public String getLengthKey() {
-		return lengthKey;
-	}
-
-	public void setLengthKey(String lengthKey) {
-		this.lengthKey = lengthKey;
-	}
-
-
-
 }

--- a/src/test/java/fact/UtilsTests.java
+++ b/src/test/java/fact/UtilsTests.java
@@ -1,6 +1,7 @@
 package fact;
-import junit.framework.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by jebuss on 14.11.16.
@@ -11,7 +12,42 @@ public class UtilsTests {
 
         double[][] empty = new double[0][0];
         double[] result = Utils.flatten2dArray(empty);
-        Assert.assertEquals(result.length, 0);
+        assertEquals(result.length, 0);
+    }
+
+    @Test
+    public void testTransformToEllipseCoordinates() {
+
+        double x = 10;
+        double y = 0;
+        double delta = 0;
+        double cogX = 20;
+        double cogY = 0;
+
+        double[] coords = Utils.transformToEllipseCoordinates(x, y, cogX, cogY, delta);
+
+        assertEquals(coords[0], -10, 1e-12);
+        assertEquals(coords[1], 0, 1e-12);
+
+        x = 10;
+        y = 10;
+        cogX = 0;
+        cogY = 10;
+        delta = Math.PI / 2;
+
+        coords = Utils.transformToEllipseCoordinates(x, y, cogX, cogY, delta);
+        assertEquals(coords[0], 0, 1e-12);
+        assertEquals(coords[1], -10, 1e-12);
+
+        x = -10;
+        y = 10;
+        cogX = 0;
+        cogY = 10;
+        delta = Math.PI / 2;
+
+        coords = Utils.transformToEllipseCoordinates(x, y, cogX, cogY, delta);
+        assertEquals(coords[0], 0, 1e-12);
+        assertEquals(coords[1], 10, 1e-12);
     }
 
 }


### PR DESCRIPTION
This reimplements ConcCore without copying the MARS code verbatim and without sticking to 1 character variable names