### PR TITLE
Implement writing of keys to the FITSWriter header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>gov.nasa.gsfc.heasarc</groupId>
       <artifactId>nom-tam-fits</artifactId>
-      <version>1.15.1</version>
+      <version>1.15.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -71,14 +71,16 @@ public class FITSWriter implements StatefulProcessor {
             outputItem.put(key, item.get(key));
         }
 
-        Data headerItem = DataFactory.create();
-        for (String key: headerKeys.select(item) ){
-            headerItem.put(key, item.get(key));
-        }
-
         if (!initialized){
             try {
                 log.info("Initialising output fits file");
+
+                Data headerItem = DataFactory.create();
+                for (String key: headerKeys.select(item) ){
+                    log.info("Saving key {} to header");
+                    headerItem.put(key, item.get(key));
+                }
+
                 initFITSFile(outputItem, headerItem);
                 initialized = true;
             } catch (FitsException e){

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -43,7 +43,7 @@ public class FITSWriter implements StatefulProcessor {
     @Parameter(required = true, description = "Keys to write to the FITS Binary Table. Using streams.Keys")
     public Keys keys = new Keys("");
 
-    @Parameter(required = true, description = "Keys to write to the FITS Header. Only the first data item will be used. Using streams.Keys")
+    @Parameter(description = "Keys to write to the FITS Header. Only the first data item will be used. Using streams.Keys")
     public Keys headerKeys = new Keys("");
 
     @Parameter(required = true, description = "Url for the output file")

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -19,7 +19,6 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.zone.ZoneRulesException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,7 +32,7 @@ import java.util.HashMap;
  * This processor is able to serialize scalars and 1d-arrays of fixed length containing primitive types.
  * Other data structures will be ignored (complex objects) or lead to errors (variable length arrays).
  *
- * The fits file is initialised using the given keys from first data item.
+ * The fits file is initialised and the header is filled using the given keys from first data item.
  * All following items must have the same structure.
  *
  */
@@ -41,21 +40,25 @@ public class FITSWriter implements StatefulProcessor {
 
     static Logger log = LoggerFactory.getLogger(FITSWriter.class);
 
-    @Parameter(required = true, description = "Keys to write to the FITS file. Using streams.Keys")
-    private Keys keys = new Keys("");
+    @Parameter(required = true, description = "Keys to write to the FITS Binary Table. Using streams.Keys")
+    public Keys keys = new Keys("");
+
+    @Parameter(required = true, description = "Keys to write to the FITS Header. Only the first data item will be used. Using streams.Keys")
+    public Keys headerKeys = new Keys("");
 
     @Parameter(required = true, description = "Url for the output file")
-    private URL url;
+    public URL url;
 
     @Parameter(defaultValue ="Events", description = "EXTNAME for the binary table extension")
-    private String extname = "Events";
+    public String extname = "Events";
 
     private BufferedFile bf;
     private ByteBuffer buffer;
     private BinaryTableHDU bhdu;
     private boolean initialized = false;
     private long rowSize;
-    private long numEventsWritten = 0;
+
+    long numEventsWritten = 0;
 
     static ArrayList<String> columnNames = new ArrayList<>(0);
     static HashMap<String, int[]> columnDimensions = new HashMap<>(0);
@@ -64,15 +67,19 @@ public class FITSWriter implements StatefulProcessor {
     @Override
     public Data process(Data item) {
         Data outputItem = DataFactory.create();
-
         for (String key: keys.select(item) ){
             outputItem.put(key, item.get(key));
+        }
+
+        Data headerItem = DataFactory.create();
+        for (String key: headerKeys.select(item) ){
+            headerItem.put(key, item.get(key));
         }
 
         if (!initialized){
             try {
                 log.info("Initialising output fits file");
-                initFITSFile(outputItem);
+                initFITSFile(outputItem, headerItem);
                 initialized = true;
             } catch (FitsException e){
                 throw new RuntimeException("Could not initialize fits file", e);
@@ -146,6 +153,44 @@ public class FITSWriter implements StatefulProcessor {
         bf.write(buffer.array());
     }
 
+    private void fillHeader(Header header, Data item) {
+        for (String key: item.keySet()) {
+            Serializable serializable = item.get(key);
+
+            if (key.length() > 8) {
+                log.warn("Key {} too long, truncating to {}", key, key.substring(0, 8));
+                key = key.substring(0, 8);
+            }
+
+            Class<? extends Serializable> type = serializable.getClass();
+            try {
+                if (ClassUtils.isAssignable(type, String.class)) {
+                    header.addValue(key, (String) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Integer.class)) {
+                    header.addValue(key, (int) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Double.class)) {
+                    header.addValue(key, (double) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Float.class)) {
+                    header.addValue(key, (float) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Short.class)) {
+                    header.addValue(key, (short) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Long.class)) {
+                    header.addValue(key, (long) serializable, "");
+                } else if (ClassUtils.isAssignable(type, Boolean.class)) {
+                    header.addValue(key, (boolean) serializable, "");
+                } else if (ClassUtils.isAssignable(type, ZonedDateTime.class)) {
+                    ZonedDateTime zonedDateTime = (ZonedDateTime) serializable;
+                    header.addValue(key, zonedDateTime.format(DateTimeFormatter.ISO_INSTANT), "");
+                } else {
+                    throw new RuntimeException("Key '" + key + "' cannot be saved to FITS Header");
+                }
+            } catch (HeaderCardException e) {
+                log.error("Could not write key {} to FITS header", key);
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     private Object wrapInArray(Serializable serializable) throws RuntimeException {
         Class<? extends Serializable> type = serializable.getClass();
 
@@ -178,7 +223,7 @@ public class FITSWriter implements StatefulProcessor {
     }
 
 
-    private void initFITSFile(Data item) throws  FitsException{
+    private void initFITSFile(Data item, Data headerItem) throws  FitsException{
         ArrayList<Object> rowList = new ArrayList<>();
         for (String columnName: item.keySet()) {
             Serializable serializable = item.get(columnName);
@@ -198,8 +243,11 @@ public class FITSWriter implements StatefulProcessor {
         log.info("Row size is {} bytes", rowSize);
         BinaryTable table = new BinaryTable();
         table.addRow(row);
+
         Header header = new Header();
         table.fillHeader(header);
+        fillHeader(header, headerItem);
+
         bhdu = new BinaryTableHDU(header, table);
 
         log.info("created bhdu with {} columns", bhdu.getData().getNCols());
@@ -241,21 +289,5 @@ public class FITSWriter implements StatefulProcessor {
         } else {
             bf.close();
         }
-    }
-
-    public void setKeys(Keys keys) {
-        this.keys = keys;
-    }
-
-    public void setUrl(URL url) {
-        this.url = url;
-    }
-
-    public void setExtname(String extname) {
-        this.extname = extname;
-    }
-
-    public long getNumEventsWritten() {
-        return numEventsWritten;
     }
 }

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -60,8 +60,8 @@ public class FITSWriter implements StatefulProcessor {
 
     long numEventsWritten = 0;
 
-    static ArrayList<String> columnNames = new ArrayList<>(0);
-    static HashMap<String, int[]> columnDimensions = new HashMap<>(0);
+    ArrayList<String> columnNames = new ArrayList<>(0);
+    HashMap<String, int[]> columnDimensions = new HashMap<>(0);
 
 
     @Override
@@ -227,7 +227,6 @@ public class FITSWriter implements StatefulProcessor {
         ArrayList<Object> rowList = new ArrayList<>();
         for (String columnName: item.keySet()) {
             Serializable serializable = item.get(columnName);
-
             try {
                 Object elem = wrapInArray(serializable);
                 rowList.add(elem);

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -78,7 +78,7 @@ public class FITSWriter implements StatefulProcessor {
 
                 Data headerItem = DataFactory.create();
                 for (String key: headerKeys.select(item) ){
-                    log.info("Saving key {} to header");
+                    log.debug("Saving key {} to header", key);
                     headerItem.put(key, item.get(key));
                 }
 

--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -183,6 +184,9 @@ public class FITSWriter implements StatefulProcessor {
                 } else if (ClassUtils.isAssignable(type, ZonedDateTime.class)) {
                     ZonedDateTime zonedDateTime = (ZonedDateTime) serializable;
                     header.addValue(key, zonedDateTime.format(DateTimeFormatter.ISO_INSTANT), "");
+                } else if (ClassUtils.isAssignable(type, LocalDateTime.class)) {
+                    LocalDateTime localDateTime = (LocalDateTime) serializable;
+                    header.addValue(key, localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME), "");
                 } else {
                     throw new RuntimeException("Key '" + key + "' cannot be saved to FITS Header");
                 }

--- a/src/test/java/fact/io/FITSWriterTest.java
+++ b/src/test/java/fact/io/FITSWriterTest.java
@@ -3,10 +3,7 @@
  */
 package fact.io;
 
-import fact.io.hdureader.BinTable;
-import fact.io.hdureader.BinTableReader;
-import fact.io.hdureader.FITS;
-import fact.io.hdureader.OptionalTypesMap;
+import fact.io.hdureader.*;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +15,6 @@ import java.io.File;
 import java.net.URL;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 
 import static org.junit.Assert.assertEquals;
 
@@ -38,7 +34,7 @@ public class FITSWriterTest {
         log.info(f.getAbsolutePath());
 
         URL url = new URL("file:" + f.getAbsolutePath());
-        fitsWriter.setUrl(url);
+        fitsWriter.url = url;
         fitsWriter.init(null);
         fitsWriter.finish();
     }
@@ -50,8 +46,8 @@ public class FITSWriterTest {
         log.info(f.getAbsolutePath());
 
         URL url = new URL("file:" + f.getAbsolutePath());
-        fitsWriter.setUrl(url);
-        fitsWriter.setKeys(new Keys("*"));
+        fitsWriter.url = url;
+        fitsWriter.keys = new Keys("*");
 
         fitsWriter.init(null);
 
@@ -69,7 +65,7 @@ public class FITSWriterTest {
         item.put("timestamp", ZonedDateTime.of(2017, 1, 1, 12, 0, 0, 991300000, ZoneOffset.UTC));
 
         fitsWriter.process(item);
-        assertEquals(fitsWriter.getNumEventsWritten(), 1);
+        assertEquals(fitsWriter.numEventsWritten, 1);
         fitsWriter.finish();
 
         FITS fits = FITS.fromFile(f);
@@ -87,5 +83,50 @@ public class FITSWriterTest {
             assertEquals(array[i], arrayRead[i], 1e-12);
         }
         assertEquals(row.get("timestamp"), "2017-01-01T12:00:00.991300Z");
+    }
+
+    @Test
+    public void testHeaderKeys() throws Exception {
+        FITSWriter fitsWriter = new FITSWriter();
+        File f = File.createTempFile("test_fits", ".fits");
+        log.info(f.getAbsolutePath());
+
+        URL url = new URL("file:" + f.getAbsolutePath());
+        fitsWriter.url = url;
+        fitsWriter.keys = new Keys("EventNum,TriggerType");
+        fitsWriter.headerKeys = new Keys("NROI,NPIX,UTCTIME,muchtoolong");
+        fitsWriter.init(null);
+
+        Data item = DataFactory.create();
+        item.put("muchtoolong", true);
+        item.put("EventNum", 1);
+        item.put("TriggerType", 4);
+        item.put("NROI", 300);
+        item.put("NPIX", 1440);
+        item.put("UTCTIME", ZonedDateTime.of(2017, 1, 1, 12, 0, 0, 991300000, ZoneOffset.UTC));
+
+
+        fitsWriter.process(item);
+        assertEquals(fitsWriter.numEventsWritten, 1);
+        fitsWriter.finish();
+
+        FITS fits = FITS.fromFile(f);
+
+        HDU hdu = fits.getHDU("Events");
+
+        Header header = hdu.header;
+
+        // test truncation of too long key
+        assertEquals(true, header.getBoolean("muchtool").get());
+
+        int nroi = header.getInt("NROI").get();
+        assertEquals(300, nroi);
+
+        assertEquals("2017-01-01T12:00:00.991300Z", header.get("UTCTIME").get());
+
+        int npix = header.getInt("NPIX").get();
+        assertEquals(1440, npix);
+
+        assertEquals(false, header.get("EventNum").isPresent());
     }
 }

--- a/src/test/java/fact/io/FITSWriterTest.java
+++ b/src/test/java/fact/io/FITSWriterTest.java
@@ -31,7 +31,7 @@ public class FITSWriterTest {
 	public void testFitsWriterNoItems() throws Exception {
         FITSWriter fitsWriter = new FITSWriter();
         File f = File.createTempFile("test_fits", ".fits");
-        log.info(f.getAbsolutePath());
+        log.info("testFitsWriterNoItems {}", f.getAbsolutePath());
 
         URL url = new URL("file:" + f.getAbsolutePath());
         fitsWriter.url = url;
@@ -41,14 +41,15 @@ public class FITSWriterTest {
 
     @Test
     public void testFitsWriter() throws Exception {
-        FITSWriter fitsWriter = new FITSWriter();
+
         File f = File.createTempFile("test_fits", ".fits");
-        log.info(f.getAbsolutePath());
+        log.info("testFitsWriter with path {}", f.getAbsolutePath());
 
         URL url = new URL("file:" + f.getAbsolutePath());
+
+        FITSWriter fitsWriter = new FITSWriter();
         fitsWriter.url = url;
         fitsWriter.keys = new Keys("*");
-
         fitsWriter.init(null);
 
         Data item = DataFactory.create();
@@ -87,11 +88,12 @@ public class FITSWriterTest {
 
     @Test
     public void testHeaderKeys() throws Exception {
-        FITSWriter fitsWriter = new FITSWriter();
-        File f = File.createTempFile("test_fits", ".fits");
-        log.info(f.getAbsolutePath());
+        File f = File.createTempFile("test_fitsheader", ".fits");
+        log.info("testHeaderKeys with path {}", f.getAbsolutePath());
 
         URL url = new URL("file:" + f.getAbsolutePath());
+
+        FITSWriter fitsWriter = new FITSWriter();
         fitsWriter.url = url;
         fitsWriter.keys = new Keys("EventNum,TriggerType");
         fitsWriter.headerKeys = new Keys("NROI,NPIX,UTCTIME,muchtoolong");


### PR DESCRIPTION
FITSWriter can now write certain keys to the header of the binary table.