### PR TITLE
Fix exception handling in loadDrsData

### DIFF
--- a/src/main/java/fact/datacorrection/DrsCalibration.java
+++ b/src/main/java/fact/datacorrection/DrsCalibration.java
@@ -85,7 +85,7 @@ public class DrsCalibration implements StatefulProcessor {
             this.drsGainRms = row.getFloatArray("GainRms").orElseThrow(() -> new RuntimeException("File does not contain key GainRms"));
 
         } catch (IOException e) {
-            new IOException(e.getMessage());
+            throw new RuntimeException(e);
         }
 
     }


### PR DESCRIPTION
An exception was only **created**, not **thrown**
  