### PR TITLE
Support classpath:/ urls for input files

### DIFF
--- a/src/main/java/fact/ClasspathURLStreamHandlerFactory.java
+++ b/src/main/java/fact/ClasspathURLStreamHandlerFactory.java
@@ -1,0 +1,29 @@
+package fact;
+
+
+import java.io.IOException;
+import java.net.*;
+
+public class ClasspathURLStreamHandlerFactory implements URLStreamHandlerFactory {
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        if ("classpath".equals(protocol)) {
+            return new ClasspathURLStreamHandler();
+        }
+
+        return null;
+    }
+
+    public class ClasspathURLStreamHandler extends URLStreamHandler {
+        /** The classloader to find resources from. */
+
+
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            final URL resourceUrl =   ClasspathURLStreamHandler.class.getResource(u.getPath());
+            return resourceUrl.openConnection();
+        }
+
+    }
+}

--- a/src/main/java/fact/datacorrection/DrsCalibration.java
+++ b/src/main/java/fact/datacorrection/DrsCalibration.java
@@ -267,10 +267,6 @@ public class DrsCalibration implements StatefulProcessor {
 
     @Override
     public void init(ProcessContext processContext) throws Exception {
-//        if(url == null && drsService == null){
-//            log.error("Url and Service are not set. You need to set one of those");
-//            throw new IllegalArgumentException("Wrong parameter");
-//        }
         if (url != null) {
             try {
                 loadDrsData(url);

--- a/src/main/java/fact/run.java
+++ b/src/main/java/fact/run.java
@@ -1,6 +1,8 @@
 package fact;
 
 
+import java.net.URL;
+
 /**
  * Main executable for the FACT-Tools,
  * this is a thin wrapper around stream.run and only changes version and help text.
@@ -8,8 +10,12 @@ package fact;
 public class run {
     public static void main(String[] args) throws Exception {
         handleArguments(args);
-        stream.run.main(args);
 
+        // Support "classpath:/path/to/resource" URLs
+        URL.setURLStreamHandlerFactory(new ClasspathURLStreamHandlerFactory());
+
+        // start streams
+        stream.run.main(args);
     }
 
     public static void handleArguments(String[] args) {


### PR DESCRIPTION
This fixes some long standing issues of using `-Ddrsfile=classpath:/testDrsFile.fits.gz`  or something similar