### PR TITLE
Update cleaning levels

### DIFF
--- a/src/main/resources/default/settings.properties
+++ b/src/main/resources/default/settings.properties
@@ -18,8 +18,8 @@ BasicExtraction.rangeHalfHeigthWindow=25
 RisingEdgePolynomFit.numberOfPoints=11
 
 # Cleaning Settings
-TwoLevelTimeNeighbor.coreThreshold=5.5
-TwoLevelTimeNeighbor.neighborThreshold=3.0
+TwoLevelTimeNeighbor.coreThreshold=5.0
+TwoLevelTimeNeighbor.neighborThreshold=2.5
 TwoLevelTimeNeighbor.timeLimit=10
 TwoLevelTimeNeighbor.minNumberOfPixel=2
 

--- a/src/site/markdown/stdAnalysis/standardAnalysis.md
+++ b/src/site/markdown/stdAnalysis/standardAnalysis.md
@@ -137,8 +137,8 @@ For example changing the cleaning level:
     [...]
     <properties url="classpath:/default/settings_mc.properties" />
 
-    <property name="TwoLevelTimeNeighbor.coreThreshold" value="5.5" />
-    <property name="TwoLevelTimeNeighbor.neighborThreshold" value="3" />
+    <property name="TwoLevelTimeNeighbor.coreThreshold" value="5.0" />
+    <property name="TwoLevelTimeNeighbor.neighborThreshold" value="2.5" />
     <property name="TwoLevelTimeNeighbor.timeLimit" value="10" />
     <property name="TwoLevelTimeNeighbor.minNumberOfPixel" value="2" />
     [...]

--- a/src/site/markdown/stdAnalysis/standardSettings.md
+++ b/src/site/markdown/stdAnalysis/standardSettings.md
@@ -9,7 +9,7 @@ Each property can be overwritten by specifing the defintion of the property late
 
     [...]
     <properties url="classpath:/default/settings_mc.properties" />
-    <property name="twoLevelTimeNeighbor_coreThreshold" value="5.5" />
+    <property name="TwoLevelTimeNeighbor.coreThreshold" value="5.0" />
     [...]
 
 Now follows the specification of the settings:


### PR DESCRIPTION
Lower cleaning levels to adapt to lower sizes as result of the GainService and new MC Gain file.

Significance on the open crab sample is now 25 σ:
![theta2_c5025](https://user-images.githubusercontent.com/5488440/37098364-002eb13c-221e-11e8-863a-43835830b476.png)
