### PR TITLE
Hdu reader skip rows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>

--- a/src/main/java/fact/io/hdureader/BinTable.java
+++ b/src/main/java/fact/io/hdureader/BinTable.java
@@ -35,6 +35,12 @@ public class BinTable {
     final DataInputStream tableDataStream;
     DataInputStream heapDataStream = null;
 
+    private final Header header;
+
+    public Header getHeader() {
+        return header;
+    }
+
 
     /**
      * This enum maps the type characters in the header to the fits types.
@@ -130,8 +136,10 @@ public class BinTable {
     public Integer numberOfRowsInTable = 0;
     public Integer numberOfColumnsInTable = 0;
     public final String name;
+    public Integer numberOfBytesPerRow = 0; // in header value: naxis1
 
     BinTable(Header header, long hduOffset, URL url) throws IllegalArgumentException, IOException {
+        this.header = header;
 
         binTableSanityCheck(header);
 
@@ -163,6 +171,7 @@ public class BinTable {
             columns.add(new TableColumn(zform, tform, ttype.getValue()));
         }
 
+        numberOfBytesPerRow = header.getInt("ZNAXIS1").orElse(header.getInt("NAXIS1").orElse(0));
         numberOfRowsInTable = header.getInt("ZNAXIS2").orElse(header.getInt("NAXIS2").orElse(0));
         numberOfColumnsInTable = columns.size();
 

--- a/src/main/java/fact/io/hdureader/BinTable.java
+++ b/src/main/java/fact/io/hdureader/BinTable.java
@@ -35,12 +35,7 @@ public class BinTable {
     final DataInputStream tableDataStream;
     DataInputStream heapDataStream = null;
 
-    private final Header header;
-
-    public Header getHeader() {
-        return header;
-    }
-
+    public final Header header;
 
     /**
      * This enum maps the type characters in the header to the fits types.

--- a/src/main/java/fact/io/hdureader/BinTableReader.java
+++ b/src/main/java/fact/io/hdureader/BinTableReader.java
@@ -38,11 +38,13 @@ public class BinTableReader implements Reader {
     private final List<BinTable.TableColumn> columns;
     private int numberOfRowsRead = 0;
     private final int numberOfRowsInTable;
+    private final int numberOfBytesPerRow;
 
 
     private BinTableReader(BinTable binTable) {
         this.stream = binTable.tableDataStream;
         this.columns = binTable.columns;
+        this.numberOfBytesPerRow = binTable.numberOfBytesPerRow;
         this.numberOfRowsInTable = binTable.numberOfRowsInTable;
     }
 
@@ -140,5 +142,14 @@ public class BinTableReader implements Reader {
                 return doubles;
         }
         return null;
+    }
+
+    @Override
+    public void skipToRow(int num) throws IOException {
+        if (num <= numberOfRowsInTable) {
+            new IndexOutOfBoundsException("Table has not enough rows to access row num: " + num);
+        }
+        stream.skipBytes(num * this.numberOfBytesPerRow);
+        numberOfRowsRead = num;
     }
 }

--- a/src/main/java/fact/io/hdureader/BinTableReader.java
+++ b/src/main/java/fact/io/hdureader/BinTableReader.java
@@ -145,11 +145,11 @@ public class BinTableReader implements Reader {
     }
 
     @Override
-    public void skipToRow(int num) throws IOException {
-        if (num <= numberOfRowsInTable) {
-            new IndexOutOfBoundsException("Table has not enough rows to access row num: " + num);
+    public void skipRows(int amount) throws IOException {
+        if (amount+numberOfRowsRead <= numberOfRowsInTable) {
+            new IndexOutOfBoundsException("Table has not enough rows to access row num: " + (amount+numberOfRowsRead));
         }
-        stream.skipBytes(num * this.numberOfBytesPerRow);
-        numberOfRowsRead = num;
+        stream.skipBytes(amount * this.numberOfBytesPerRow);
+        numberOfRowsRead += amount;
     }
 }

--- a/src/main/java/fact/io/hdureader/BinTableReader.java
+++ b/src/main/java/fact/io/hdureader/BinTableReader.java
@@ -144,6 +144,12 @@ public class BinTableReader implements Reader {
         return null;
     }
 
+    /**
+     * Skips the given number of rows.
+     *
+     * @param num The amount of rows to skip.
+     * @throws IOException
+     */
     @Override
     public void skipRows(int amount) throws IOException {
         if (amount+numberOfRowsRead <= numberOfRowsInTable) {

--- a/src/main/java/fact/io/hdureader/FITSStream.java
+++ b/src/main/java/fact/io/hdureader/FITSStream.java
@@ -128,7 +128,7 @@ public class FITSStream extends AbstractStream {
         return item;
     }
 
-    public Reader getReader() {
-        return reader;
+    public void skipToRow(int num) throws IOException{
+        reader.skipToRow(num);
     }
 }

--- a/src/main/java/fact/io/hdureader/FITSStream.java
+++ b/src/main/java/fact/io/hdureader/FITSStream.java
@@ -127,4 +127,8 @@ public class FITSStream extends AbstractStream {
 
         return item;
     }
+
+    public Reader getReader() {
+        return reader;
+    }
 }

--- a/src/main/java/fact/io/hdureader/FITSStream.java
+++ b/src/main/java/fact/io/hdureader/FITSStream.java
@@ -128,7 +128,13 @@ public class FITSStream extends AbstractStream {
         return item;
     }
 
-    public void skipToRow(int num) throws IOException{
-        reader.skipToRow(num);
+    /**
+     * Skips the given amount of rows in the data table.
+     *
+     * @param amount The amount of Rows to skip.
+     * @throws IOException
+     */
+    public void skipRows(int amount) throws IOException{
+        reader.skipRows(amount);
     }
 }

--- a/src/main/java/fact/io/hdureader/Reader.java
+++ b/src/main/java/fact/io/hdureader/Reader.java
@@ -72,5 +72,12 @@ public interface Reader extends
      */
     OptionalTypesMap<String, Serializable> getNextRow() throws IOException;
 
+    /**
+     * Skips the given number of rows.
+     *
+     * @param num The amount of rows to skip.
+     * @throws IOException
+     */
+    void skipToRow(int num) throws IOException;
 
 }

--- a/src/main/java/fact/io/hdureader/Reader.java
+++ b/src/main/java/fact/io/hdureader/Reader.java
@@ -78,6 +78,6 @@ public interface Reader extends
      * @param num The amount of rows to skip.
      * @throws IOException
      */
-    void skipToRow(int num) throws IOException;
+    void skipRows(int amount) throws IOException;
 
 }

--- a/src/main/java/fact/io/hdureader/ZFITSHeapReader.java
+++ b/src/main/java/fact/io/hdureader/ZFITSHeapReader.java
@@ -125,11 +125,7 @@ public final class ZFITSHeapReader implements Reader {
         if (resultingRow >= this.numberOfRowsInTable) {
             throw new IOException("Not enough rows in table, need "+(amount+numberOfRowsRead)+" have "+numberOfRowsInTable);
         }
-
-        /*for (int i=0; i<amount; i++) {
-            getNextRow();
-        }
-        return;*/
+        
         // check if resulting row is in the current catalog remainer
         int remainer = zTileLen - numberOfRowsRead%zTileLen;
         if (amount<remainer) { // no need to deal with the catalog as we just work within one
@@ -203,7 +199,6 @@ public final class ZFITSHeapReader implements Reader {
         this.numberOfRowsRead += diffCatalogs * this.zTileLen;
 
         int remainingRows = resultingRow % zTileLen;
-        //System.out.println("Rem: "+remainingRows);
         for (int i=0; i<remainingRows; i++) {
             getNextRow();
         }

--- a/src/test/java/fact/io/hdureader/FitsHDUTests.java
+++ b/src/test/java/fact/io/hdureader/FitsHDUTests.java
@@ -46,7 +46,7 @@ public class FitsHDUTests {
         fits.readNext();
         fits.readNext();
         Data item = fits.readNext();
-        fits2.skipToRow(2);
+        fits2.skipRows(2);
         Data item2 = fits2.readNext();
 
 
@@ -74,7 +74,7 @@ public class FitsHDUTests {
             }
             Data item = fits.readNext();
 
-            fits2.skipToRow(i);
+            fits2.skipRows(i);
             Data item2 = fits2.readNext();
 
 
@@ -103,7 +103,7 @@ public class FitsHDUTests {
             }
             Data item = fits.readNext();
 
-            fits2.skipToRow(i);
+            fits2.skipRows(i);
             Data item2 = fits2.readNext();
 
 
@@ -132,7 +132,7 @@ public class FitsHDUTests {
             }
             Data item = fits.readNext();
 
-            fits2.skipToRow(i);
+            fits2.skipRows(i);
             Data item2 = fits2.readNext();
 
 

--- a/src/test/java/fact/io/hdureader/FitsHDUTests.java
+++ b/src/test/java/fact/io/hdureader/FitsHDUTests.java
@@ -46,8 +46,7 @@ public class FitsHDUTests {
         fits.readNext();
         fits.readNext();
         Data item = fits.readNext();
-        Reader reader = fits2.getReader();
-        reader.skipToRow(2);
+        fits2.skipToRow(2);
         Data item2 = fits2.readNext();
 
 
@@ -69,14 +68,71 @@ public class FitsHDUTests {
             fits.init();
             FITSStream fits2 = new FITSStream(new SourceURL(u));
             fits2.init();
-            //read 3
+
             for (int j = 0; j < i; j++) {
                 fits.readNext();
             }
             Data item = fits.readNext();
 
-            Reader reader = fits2.getReader();
-            reader.skipToRow(i);
+            fits2.skipToRow(i);
+            Data item2 = fits2.readNext();
+
+
+            int eNr = (int) item.get("EventNum");
+            int eNr2 = (int) item2.get("EventNum");
+            assertEquals(eNr, eNr2);
+
+            short[] data = (short[]) item.get("Data");
+            short[] data2 = (short[]) item2.get("Data");
+            assertArrayEquals(data, data2);
+        }
+    }
+
+    @Test
+    public void testZFitsReaderSkipWithZShrink() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            System.out.println("Test skip: " + i);
+            URL u = FitsHDUTests.class.getResource("/testDataFileZSHRINK.fits.fz");
+            FITSStream fits = new FITSStream(new SourceURL(u));
+            fits.init();
+            FITSStream fits2 = new FITSStream(new SourceURL(u));
+            fits2.init();
+
+            for (int j = 0; j < i; j++) {
+                fits.readNext();
+            }
+            Data item = fits.readNext();
+
+            fits2.skipToRow(i);
+            Data item2 = fits2.readNext();
+
+
+            int eNr = (int) item.get("EventNum");
+            int eNr2 = (int) item2.get("EventNum");
+            assertEquals(eNr, eNr2);
+
+            short[] data = (short[]) item.get("Data");
+            short[] data2 = (short[]) item2.get("Data");
+            assertArrayEquals(data, data2);
+        }
+    }
+
+    @Test
+    public void testZFitsReaderSkipWithZTileLen() throws Exception {
+        for (int i = 98; i < 102; i++) {
+            System.out.println("Test skip: " + i);
+            URL u = FitsHDUTests.class.getResource("/testDataFileZTILELEN.fits.fz");
+            FITSStream fits = new FITSStream(new SourceURL(u));
+            fits.init();
+            FITSStream fits2 = new FITSStream(new SourceURL(u));
+            fits2.init();
+
+            for (int j = 0; j < i; j++) {
+                fits.readNext();
+            }
+            Data item = fits.readNext();
+
+            fits2.skipToRow(i);
             Data item2 = fits2.readNext();
 
 

--- a/src/test/java/fact/io/hdureader/FitsHDUTests.java
+++ b/src/test/java/fact/io/hdureader/FitsHDUTests.java
@@ -61,7 +61,7 @@ public class FitsHDUTests {
 
     @Test
     public void testZFitsReaderSkip() throws Exception {
-        for (int i = 0; i < 5; i++) {
+        for (int i = 2; i < 5; i++) {
             System.out.println("Test skip: " + i);
             URL u = FitsHDUTests.class.getResource("/testDataFile.fits.fz");
             FITSStream fits = new FITSStream(new SourceURL(u));
@@ -76,8 +76,7 @@ public class FitsHDUTests {
 
             fits2.skipRows(i);
             Data item2 = fits2.readNext();
-
-
+            
             int eNr = (int) item.get("EventNum");
             int eNr2 = (int) item2.get("EventNum");
             assertEquals(eNr, eNr2);

--- a/src/test/java/fact/io/hdureader/FitsHDUTests.java
+++ b/src/test/java/fact/io/hdureader/FitsHDUTests.java
@@ -2,6 +2,9 @@ package fact.io.hdureader;
 
 import org.junit.Test;
 
+import stream.io.SourceURL;
+import stream.Data;
+
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -31,6 +34,61 @@ public class FitsHDUTests {
 
     }
 
+    @Test
+    public void testBinTableReaderSkip() throws Exception {
+        URL u = FitsHDUTests.class.getResource("/testDataFile.fits.gz");
+        FITSStream fits = new FITSStream(new SourceURL(u));
+        fits.init();
+        FITSStream fits2 = new FITSStream(new SourceURL(u));
+        fits2.init();
+
+        //read 3
+        fits.readNext();
+        fits.readNext();
+        Data item = fits.readNext();
+        Reader reader = fits2.getReader();
+        reader.skipToRow(2);
+        Data item2 = fits2.readNext();
+
+
+        int eNr = (int) item.get("EventNum");
+        int eNr2 = (int) item2.get("EventNum");
+        assertEquals(eNr, eNr2);
+
+        short[] data = (short[]) item.get("Data");
+        short[] data2 = (short[]) item2.get("Data");
+        assertArrayEquals(data, data2);
+    }
+
+    @Test
+    public void testZFitsReaderSkip() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            System.out.println("Test skip: " + i);
+            URL u = FitsHDUTests.class.getResource("/testDataFile.fits.fz");
+            FITSStream fits = new FITSStream(new SourceURL(u));
+            fits.init();
+            FITSStream fits2 = new FITSStream(new SourceURL(u));
+            fits2.init();
+            //read 3
+            for (int j = 0; j < i; j++) {
+                fits.readNext();
+            }
+            Data item = fits.readNext();
+
+            Reader reader = fits2.getReader();
+            reader.skipToRow(i);
+            Data item2 = fits2.readNext();
+
+
+            int eNr = (int) item.get("EventNum");
+            int eNr2 = (int) item2.get("EventNum");
+            assertEquals(eNr, eNr2);
+
+            short[] data = (short[]) item.get("Data");
+            short[] data2 = (short[]) item2.get("Data");
+            assertArrayEquals(data, data2);
+        }
+    }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test


### PR DESCRIPTION
Added the ability to skip rows in the HDU reader. This is nedded for the SamplePedestalEvent processor that is coming in a later pull request.

This is the second part of the pull request simplification of #246 and can be merged independently of #348.