### PR TITLE
Streams1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>de.sfb876</groupId>
   <artifactId>fact-tools</artifactId>
   <name>fact-tools</name>
-  <version>1.0.1</version>
+  <version>1.0.2-SNAPSHOT</version>
   <url>http://sfb876.de/fact-tools/</url>
 
   <description>
@@ -15,7 +15,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <streams.scope>compile</streams.scope>
-    <streams.version>1.0.0</streams.version>
+    <streams.version>1.0.5</streams.version>
     <binary.name>fact-tools-${git.commit.id.describe}</binary.name>
     <skipTests>false</skipTests>
     <finalName>fact-tools-${git.commit.id.describe}</finalName>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -13,9 +13,10 @@ log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{MMM dd yyyy HH:mm:ss} [%-5p] %C: %m%n
 
-log4j.logger.stream=INFO
+log4j.logger.stream=ERROR
+log4j.logger.stream.util=ERROR
 log4j.logger.stream.run=ERROR
-log4j.logger.stream.runtime=INFO
+log4j.logger.stream.runtime=ERROR
 log4j.logger.net.scinotes=INFO
 log4j.logger.net=INFO
 log4j.logger.org.springframework=INFO

--- a/src/test/java/fact/FunctionalTest.java
+++ b/src/test/java/fact/FunctionalTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import static fact.RunFACTTools.runFACTTools;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -58,6 +59,12 @@ public class FunctionalTest {
             String[] args = {f.toAbsolutePath().toString()};
             try {
                 runFACTTools(args);
+            } catch (RunFACTTools.SystemExitException e) {
+                if (e.status != 0) {
+                    log.error("Error executing xml: " + f, e);
+                    failedFilesList.add(f.toString());
+                    counter++;
+                }
             } catch (Exception e) {
                 log.error("Error executing xml: " + f, e);
                 failedFilesList.add(f.toString());
@@ -65,9 +72,9 @@ public class FunctionalTest {
             }
         }
 
-        log.debug("\n\n" + counter + " of " + size + " files in  'examples/studies' failed to execute");
-        log.debug(Arrays.toString(failedFilesList.toArray()));
+        String msg =  counter + " of " + size + " files in  'examples/studies' failed to execute: ";
+        msg += Arrays.toString(failedFilesList.toArray());
 
-        assertThat(failedFilesList.size(), is(0));
+        assertEquals(msg, 0, failedFilesList.size());
     }
 }

--- a/src/test/java/fact/RunFACTTools.java
+++ b/src/test/java/fact/RunFACTTools.java
@@ -1,6 +1,26 @@
 package fact;
 
+import java.security.Permission;
+
 public class RunFACTTools {
+
+    static class SystemExitException extends SecurityException {
+        final public int status;
+
+        SystemExitException(int status) {
+            super("SystemExit called with status code " + status);
+            this.status = status;
+        }
+    }
+
+    static class CatchSystemExitSecurityManager extends SecurityManager {
+        @Override public void checkExit(int status) {
+            throw new SystemExitException(status);
+        }
+
+        @Override public void checkPermission(Permission perm) {}
+    }
+
     public static void runFACTTools(String[] args) throws Exception {
         System.clearProperty("drsfile");
         System.clearProperty("infile");
@@ -10,6 +30,14 @@ public class RunFACTTools {
         System.clearProperty("integralGainFile");
         System.clearProperty("aux_source");
         System.clearProperty("output");
-        fact.run.main(args);
+
+        // Catch the system exit stream calls when an error happens
+        SecurityManager before = System.getSecurityManager();
+        System.setSecurityManager(new CatchSystemExitSecurityManager());
+        try {
+            fact.run.main(args);
+        } finally {
+            System.setSecurityManager(before);
+        }
     }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -14,6 +14,7 @@ log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d{MMM dd yyyy HH:mm:ss} [%-5p] %C: %m%n
 
 log4j.logger.fact=INFO
-#log4j.logger.fact.io=DEBUG
-#log4j.logger.org.apache=DEBUG
-#log4j.logger.com=DEBUG
+log4j.logger.stream=ERROR
+log4j.logger.stream.util=ERROR
+log4j.logger.stream.run=ERROR
+log4j.logger.stream.runtime=ERROR


### PR DESCRIPTION
This fixes #343 by updating the streams version.

Fixing #343 revealed a failing test, the std_analysis_on_reconstructed_data.xml did not execute anymore because of `-Infinity` values in `photoncharge`. 

I fixed this by adapting the `InterpolatePixelArray` Processor to also interpolate pixels with non-finite values.

I also raised all streams related logging levels to "Error" to reduce noise during execution and tests. 