### PR TITLE
Fix bug in the testKey function

### DIFF
--- a/src/main/java/fact/io/FITSWriter.java
+++ b/src/main/java/fact/io/FITSWriter.java
@@ -82,7 +82,7 @@ public class FITSWriter extends Writer implements StatefulProcessor {
         for (String key : keys.select(item)) {
             outputItem.put(key, item.get(key));
         }
-        testKeys(item, keys, allowNullKeys);
+        testKeys(outputItem, keys, allowNullKeys);
 
         if (!initialized) {
             try {

--- a/src/main/java/fact/io/Writer.java
+++ b/src/main/java/fact/io/Writer.java
@@ -71,7 +71,8 @@ public abstract class Writer {
             previousKeySet = item.keySet();
         } else {
             if (!previousKeySet.equals(item.keySet())) {
-                Set<String> diff1 = item.keySet();
+                Set<String> diff1 = new HashSet<String>();
+                diff1.addAll(item.keySet());
                 diff1.removeAll(previousKeySet);
                 Set<String> diff2 = previousKeySet;
                 diff2.removeAll(item.keySet());


### PR DESCRIPTION
Due to the reason that the `item.keySet()` is immutable we need to handle the testKeys function slightly different otherwise it will fail, if the keys are not the same (Which will make the process fail anyway but the error message will be wrong).

Also fixed the testKeys call in the FITSWriter now testing the correct dataset.