### PR TITLE
Update surefire and useSystemClassLoader=false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,8 +320,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.22.1</version>
         <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
           <skipTests>${skipTests}</skipTests>
           <argLine>-Xmx2048m</argLine>
         </configuration>


### PR DESCRIPTION
This fixes an error encountered with openjdk 1.8.0_181:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925