### PR TITLE
Gain rescaling

### DIFF
--- a/src/main/java/fact/pedestalSuperposition/rescaleDataArray.java
+++ b/src/main/java/fact/pedestalSuperposition/rescaleDataArray.java
@@ -1,0 +1,113 @@
+package fact.pedestalSuperposition;
+
+import fact.Constants;
+import fact.Utils;
+import fact.gainservice.GainService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import stream.Data;
+import stream.ProcessContext;
+import stream.StatefulProcessor;
+import stream.annotations.Parameter;
+import stream.annotations.Service;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+
+/**
+ * Rescale the amplitudes in a data array from one gain to annother.
+ * This allows, e.g., to combine data arrays from data and MCs that have
+ * different gains
+ *
+ * @author Jens Buß
+ *
+ */
+public class rescaleDataArray implements StatefulProcessor {
+    private static final Logger log = LoggerFactory.getLogger(rescaleDataArray.class);
+
+    @Parameter(required = true, description = "key to the data array to read")
+    public String dataKey = null;
+
+    @Parameter(required = true, description = "key to the data array to store")
+    public String outputKey = null;
+
+    @Service(description = "Gain Service that delivers the integral gains")
+    public GainService gainService = null;
+
+    @Parameter(required = false, description = "Wheather to scale from data gain to mc" +
+            "gain (true) or vice versa (false)", defaultValue = "true")
+    public boolean dataToMc = true;
+
+    @Parameter(required = false, description = "The key to the timestamp of the Event.")
+    public String timeStampKey = "timestamp";
+
+    private double[] mcGains;
+
+    @Override
+    public Data process(Data item) {
+
+        Utils.mapContainsKeys(item, dataKey, "NROI");
+
+        ZonedDateTime timestamp = Utils.getTimeStamp(item, timeStampKey);
+        double[] dataGains = gainService.getGains(timestamp);
+
+        int roi = (Integer) item.get("NROI");
+
+        double[] data = (double[]) item.get(dataKey);
+
+
+        double[] result = rescaleDataArray(data, dataGains, mcGains, dataToMc, roi);
+
+        item.put(outputKey, result);
+
+        return item;
+    }
+
+    public static double[] rescaleDataArray(double[] data, double[] dataGains, double[] mcGains, boolean dataToMc, int roi) {
+        double[] result = Arrays.copyOf(data, data.length);
+
+        for (int pix = 0; pix < Constants.N_PIXELS; pix++) {
+            for (int sl = 0; sl < roi; sl++) {
+                int pos = pix*roi+sl;
+
+                // In case of bad pixels the gain calibration value might be 0
+                // Don't scale in this case
+                if ((dataGains[pix] == 0) || (dataGains[pix] == 0)){
+                    continue;
+                }
+
+
+                if (dataToMc){
+                    result[pos] /= dataGains[pix];
+                    result[pos] *= mcGains[pix];
+                } else {
+                    result[pos] /= mcGains[pix];
+                    result[pos] *= dataGains[pix];
+                }
+            }
+        }
+        return result;
+    }
+
+
+    @Override
+    public void init(ProcessContext processContext) throws Exception {
+        this.mcGains = gainService.getSimulationGains();
+        log.warn("Bad pixel cannot be rescaled and "+
+                "rescaling is skipped for these pixel. " +
+                "Make sure to interpolate the bad pixels");
+
+    }
+
+    @Override
+    public void resetState() throws Exception {
+
+    }
+
+    @Override
+    public void finish() throws Exception {
+
+    }
+
+
+}

--- a/src/test/java/fact/pedestalSuperposition/rescaleDataArrayTest.java
+++ b/src/test/java/fact/pedestalSuperposition/rescaleDataArrayTest.java
@@ -1,0 +1,54 @@
+package fact.pedestalSuperposition;
+
+import fact.Constants;
+import fact.gainservice.GainService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class rescaleDataArrayTest {
+
+    private Random random = new Random();
+
+    private double[] data;
+    private GainService gainService = new GainService();
+
+    private double[] mcGains = gainService.getSimulationGains();
+    private double[] dataGains = gainService.getGains(ZonedDateTime.of(2017, 1, 1, 22, 20, 0, 0, ZoneOffset.UTC));
+
+    @Before
+    public void init(){
+        data = random.doubles(Constants.N_PIXELS * 1, -10, 300).toArray();
+    }
+
+    @Test
+    public void testIdentityMCRescaleDataArray() {
+
+        double[] result = rescaleDataArray.rescaleDataArray(data, mcGains, mcGains, true,  1);
+        Assert.assertArrayEquals(data, result, 0.005);
+    }
+
+    @Test
+    public void testIdentityDataRescaleDataArray() {
+
+        double[] result_mc = rescaleDataArray.rescaleDataArray(data, dataGains, dataGains, true,  1);
+        Assert.assertArrayEquals(data, result_mc, 0.005);
+    }
+
+    @Test
+    public void testMcConstantsRescaleDataArray() {
+
+        double[] result = rescaleDataArray.rescaleDataArray(data, dataGains, mcGains,true,  1);
+
+        double[] back_trafo = rescaleDataArray.rescaleDataArray(result, dataGains, mcGains,false,  1);
+
+        Assert.assertArrayEquals(back_trafo, data, 0.5);
+    }
+}


### PR DESCRIPTION
WIP:

adds a processor to rescale a data array from mc gain to data gain and vice versa. This is necessary for the pedestal superposition since MC and data gain differ intrinsically. Accordingly the MCs have to be calibrated with the MC gain and the pedestal events with the data gain.

In order to overcome this, this processor allows to rescale the data array (meaning the time series) from mc gain to data gain, by dividing the time series of each pixel through the pixels data gain and multiplying with the mc gain. 